### PR TITLE
Use "npm ci" on dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ FROM node:current-buster
 WORKDIR /app
 COPY ./package* ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:latest
 WORKDIR /app
 COPY ./package* ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 


### PR DESCRIPTION
## 🗣 Description

This will make things faster, and, additionally, shouldn't change a developer's workflow, because they need to install packages anyway (which updates package.json and package-lock.json) before starting Docker.