### PR TITLE
Don't error when no search results found

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -41,7 +41,6 @@ export const Dashboard: React.FC = () => {
               )
           }
         });
-        console.log(result[0].web);
         setDomains(result);
         setCount(count);
         setPageCount(Math.ceil(count / PAGE_SIZE));


### PR DESCRIPTION
## 🗣 Description

When no search results are found, `result` is an empty array, so I get the error "Cannot read property 'web' of undefined" in the console. This PR removes that log statement so there's no error.