### PR TITLE
Switch IS_OFFLINE to IS_LOCAL in tasks

### DIFF
--- a/backend/src/tasks/amass.ts
+++ b/backend/src/tasks/amass.ts
@@ -5,8 +5,8 @@ import { plainToClass } from 'class-transformer';
 import { saveDomainToDb } from './helpers';
 import { readFileSync } from 'fs';
 
-const LAYER_PATH = process.env.IS_OFFLINE ? '/app/layers' : '/opt';
-const OUT_PATH = process.env.IS_OFFLINE ? 'out.json' : '/tmp/out.json';
+const LAYER_PATH = process.env.IS_LOCAL ? '/app/layers' : '/opt';
+const OUT_PATH = process.env.IS_LOCAL ? 'out.json' : '/tmp/out.json';
 
 export const handler: Handler = async (event) => {
   await connectToDatabase();

--- a/backend/src/tasks/findomain.ts
+++ b/backend/src/tasks/findomain.ts
@@ -5,13 +5,13 @@ import { readFileSync } from 'fs';
 import { saveDomainToDb } from './helpers';
 import { plainToClass } from 'class-transformer';
 
-const LAYER_PATH = process.env.IS_OFFLINE ? '/app/layers' : '/opt';
-const OUT_PATH = process.env.IS_OFFLINE ? 'out.json' : '/tmp/out.json';
+const LAYER_PATH = process.env.IS_LOCAL ? '/app/layers' : '/opt';
+const OUT_PATH = process.env.IS_LOCAL ? 'out.json' : '/tmp/out.json';
 
 export const handler: Handler = async (event) => {
   await connectToDatabase();
 
-  if (process.env.IS_OFFLINE) {
+  if (process.env.IS_LOCAL) {
     spawnSync('chmod', ['+x', LAYER_PATH + '/findomain/findomain'], {
       stdio: 'pipe'
     });

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -4,7 +4,7 @@ import { Lambda, Credentials } from 'aws-sdk';
 
 export const handler: Handler = async (event) => {
   let args = {};
-  if (process.env.IS_OFFLINE) {
+  if (process.env.IS_LOCAL) {
     args = {
       apiVersion: '2015-03-31',
       endpoint: 'http://backend:3002',


### PR DESCRIPTION
## 🗣 Description

Switch IS_OFFLINE to the IS_LOCAL environment variable in task lambda functions.

## 💭 Motivation and Context

For each task, we need to know if they are being invoked locally in order to let them properly work locally. Currently, use use `process.env.IS_OFFLINE` to check this. However, IS_OFFLINE is only set when serverless-offline is used to invoke the lambda functions.

However, we do not use serverless-offline to invoke task functions locally (we only use it for the API functions). We use `sls invoke local` to invoke task functions locally -- so we need to use the `process.env.IS_LOCAL` variable instead. See https://github.com/serverless/serverless/issues/3639 for more information.

## 🧪 Testing

Ran `findomain` locally and it worked (previously, it broke because of incorrect local detection).