### PR TITLE
Add skipLibCheck to speed up backend typescript compilation

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,7 +14,8 @@
     "strictPropertyInitialization": false,
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "skipLibCheck": true
   },
   "include": ["./**/*"]
 }


### PR DESCRIPTION
## 🗣 Description

Add skipLibCheck to speed up backend typescript compilation. This will make it faster to invoke local functions, as well, since they involve a typescript compilation.

Stats -- running `npx tsc --diagnostics` from the backend directory:

Before this PR:

```
I/O read:         0.14s
I/O write:        0.01s
Parse time:       3.64s
Bind time:        1.12s
Check time:       5.45s
Emit time:        0.31s
Total time:      10.51s
```

After this PR:

```
I/O read:         0.09s
I/O write:        0.01s
Parse time:       2.95s
Bind time:        0.96s
Check time:       0.30s
Emit time:        0.28s
Total time:       4.49s
```