### PR TITLE
Fix terraform domains

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -19,9 +19,9 @@ resource "aws_ssm_parameter" "prod_api_domain" {
 }
 
 resource "aws_ssm_parameter" "stage_api_domain" {
-  name      = "staging.crossfeed.cyber.dhs.gov"
+  name      = "/crossfeed/staging/DOMAIN"
   type      = "String"
-  value     = "stage.api.crossfeed2.dds.mil"
+  value     = "staging.crossfeed.cyber.dhs.gov"
   overwrite = true
 
   tags = {


### PR DESCRIPTION
## 🗣 Description

These are the right domains. I had to change these values, otherwise it was trying to overwrite the existing SSM parameters on the CISA AWS account with the `.dds.mil` values.