### PR TITLE
Show signup screen for global admins

### DIFF
--- a/frontend/src/pages/AuthCreateAccount/AuthCreateAccount.tsx
+++ b/frontend/src/pages/AuthCreateAccount/AuthCreateAccount.tsx
@@ -87,7 +87,7 @@ export const AuthCreateAccount: React.FC = () => {
         Is your organization not yet on Crossfeed? Contact{' '}
         <a href="# ">crossfeed@example.gov</a> to learn more.
       </p>
-      {process.env.NODE_ENV === 'development' && (
+      {process.env.NODE_ENV === 'development' || (user && user.userType === 'globalAdmin') && (
         <>
           <h1>[DEVELOPMENT] Finish Creating Account</h1>
           <p>


### PR DESCRIPTION
Otherwise, when you call `createGlobalAdmin` to create a global admin account, you can't actually set up the user, as the following screen just shows up:

![image](https://user-images.githubusercontent.com/1689183/88420577-1434ca00-cdb5-11ea-82c2-b35014983db0.png)
