### PR TITLE
Add defaults for terraform vars

### DIFF
--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -55,10 +55,12 @@ variable ssm_lambda_subnet {
 
 variable ssm_worker_sg {
   type    = string
+  default = ""
 }
 
 variable ssm_worker_subnet {
   type    = string
+  default = ""
 }
 
 variable db_table_name {


### PR DESCRIPTION
This just makes it a bit easier to run commands like `terraform state mv`, so the console doesn't prompt you for these variables when it is run.