### PR TITLE
Change timeout / schedule of scheduler to 5 minutes

### DIFF
--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -1,8 +1,8 @@
 scheduler:
   handler: src/tasks/scheduler.handler
-  timeout: 900
+  timeout: 300
   events:
-    - schedule: rate(1 minute)
+    - schedule: rate(5 minutes)
 
 syncdb:
   handler: src/tasks/syncdb.handler


### PR DESCRIPTION
We don't want two instances of scheduler running at the same time -- this might especially be more common because censysipv4 ends up launching 100 fargate tasks.

1 minute seems too frequent, so I changed it to 5 minutes for now. We might want to increase this timeout later (maybe to 15 minutes?)