### PR TITLE
Fix getAllDomains

### DIFF
--- a/backend/src/tasks/helpers/getAllDomains.ts
+++ b/backend/src/tasks/helpers/getAllDomains.ts
@@ -4,7 +4,7 @@ import { Domain, connectToDatabase } from '../../models';
 export default async (): Promise<Domain[]> => {
   await connectToDatabase();
 
-  const qs = Domain.createQueryBuilder('domain').select('name', 'ip');
-
-  return await qs.getMany();
+  return Domain.find({
+    select: ['id', 'name', 'ip']
+  });
 };

--- a/backend/src/tasks/test/helpers/getAllDomains.test.ts
+++ b/backend/src/tasks/test/helpers/getAllDomains.test.ts
@@ -1,0 +1,24 @@
+import getAllDomains from '../../helpers/getAllDomains';
+import { Domain, connectToDatabase } from '../../../models';
+
+describe('getAllDomains', () => {
+  beforeAll(async () => {
+    await connectToDatabase();
+  });
+  test('basic test', async () => {
+    const name = Math.random() + '';
+    const ip = Math.random() + '';
+    const domain = await Domain.create({
+      name,
+      ip
+    }).save();
+    const domains = await getAllDomains();
+    expect(domains.length).toBeGreaterThan(0);
+    const domainIndex = domains.map((e) => e.id).indexOf(domain.id);
+    expect(domains[domainIndex]).toEqual({
+      id: domain.id,
+      name,
+      ip
+    });
+  });
+});


### PR DESCRIPTION
The change to getAllDomains in #100 with queryBuilder actually ended up making that function always return an empty array. I've changed this function to just use `Domain.find` (which is simpler and seems to work better), and added tests for this function as well.