### PR TITLE
Don't show censys ipv4 results if no results are there

### DIFF
--- a/frontend/src/components/ServicesTable/ServicesTable.tsx
+++ b/frontend/src/components/ServicesTable/ServicesTable.tsx
@@ -24,14 +24,15 @@ export const ServicesTable: React.FC<Props> = ({ services }) => {
             <CodeBlock>{original.banner}</CodeBlock>
           </>
         )}
-        {original.censysIpv4Results && (
-          <>
-            <h4>Censys IPv4 Results</h4>
-            <CodeBlock>
-              {JSON.stringify(original.censysIpv4Results, null, 2)}
-            </CodeBlock>
-          </>
-        )}
+        {original.censysIpv4Results &&
+          Object.keys(original.censysIpv4Results)?.length === 0 && (
+            <>
+              <h4>Censys IPv4 Results</h4>
+              <CodeBlock>
+                {JSON.stringify(original.censysIpv4Results, null, 2)}
+              </CodeBlock>
+            </>
+          )}
       </div>
     );
   }, []);


### PR DESCRIPTION
We currently show this even if the censys ipv4 results are empty (meaning, likely, that a scan has not gotten to this service yet). This is because, by default, `censysIpv4Results` is an empty object.

![image](https://user-images.githubusercontent.com/1689183/88725583-54b87e80-d0fa-11ea-8747-a2091dc8adbc.png)

This PR fixes that to only show the "censys ipv4 results" section if there actually are results.