### PR TITLE
Censys IPv4 enhancements

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -68,7 +68,7 @@ export const SCAN_SCHEMA: ScanSchema = {
     global: true,
     cpu: '1024',
     memory: '4096',
-    numChunks: 100
+    numChunks: 20
   }
 };
 

--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -91,8 +91,13 @@ const downloadPath = async (
     readInterface.on('SIGCONT', reject);
     readInterface.on('SIGTSTP', reject);
   });
+  if (!domains.length) {
+    console.log(
+      `censysipv4 - processed file ${i} of ${numFiles}: got no results`
+    );
+  }
   console.log(
-    `i: ${i} of ${numFiles}: got ${domains.length} domains and ${services.length} services`
+    `censysipv4 - processed file ${i} of ${numFiles}: got some results: ${domains.length} domains and ${services.length} services`
   );
 
   await saveDomainsToDb(domains);

--- a/backend/src/tasks/test/scheduler.test.ts
+++ b/backend/src/tasks/test/scheduler.test.ts
@@ -218,7 +218,7 @@ describe('scheduler', () => {
     );
 
     // Calls scan in chunks
-    expect(runCommand).toHaveBeenCalledTimes(100);
+    expect(runCommand).toHaveBeenCalledTimes(20);
     expect(runCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: undefined,


### PR DESCRIPTION
The censys ipv4 scan has worked -- see https://staging.crossfeed.cyber.dhs.gov/domain/0afbc3c0-5638-4248-bd9a-9f3c7ab0f6cd, for example. This PR makes a few improvements:

- Reduce worker concurrency from 100 -> 20. This might address #156 (as I tested running 20 workers at a time before with no problem), and the entire scan should still take around an hour.
- Make logging from worker more descriptive, so it's easier to search log groups to tell which files actually contained relevant domains (by searching for "got some results")