### PR TITLE
Remove the "fargate vs lambda" section from worker docs

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -1,7 +1,7 @@
 # Worker architecture
 
 The `Scan` model represents a scheduled scan that is run on all organizations.
-A scan can be of multiple types -- for example, `amass`, or `findomain`.
+A scan can be of multiple types -- for example, `amass` , or `findomain` .
 
 First, add an organization:
 
@@ -24,7 +24,7 @@ All information needed for the scan (defined in the `CommandOptions` interface) 
 through the `CROSSFEED_COMMAND_OPTIONS` environment variable. Other secrets needed for the Fargate
 task to run are specified in the task configuration through Terraform.
 
-The entry point for the Fargate task is at `backend/src/worker.ts`.
+The entry point for the Fargate task is at `backend/src/worker.ts` .
 
 ![fargate task](https://github.com/cisagov/crossfeed/raw/62b27371d4a33f104452967dde1a85d1946da6c8/docs/img/fargate%20task.png)
 
@@ -32,13 +32,13 @@ The entry point for the Fargate task is at `backend/src/worker.ts`.
 
 When running Crossfeed locally, each worker is launched through a Docker container instead.
 
-To inspect tasks that are running (and have recently finished), do `docker ps -a > out` and inspect the contents of `out`:
+To inspect tasks that are running (and have recently finished), do `docker ps -a > out` and inspect the contents of `out` :
 
 ![docker ps](https://github.com/cisagov/crossfeed/raw/62b27371d4a33f104452967dde1a85d1946da6c8/docs/img/docker%20ps.png)
 
 Note that each Docker container is identified by organization name and scan name.
 
-To view the logs of a particular Docker container, you can run `docker logs crossfeed_worker_cisa_censys_8358453`.
+To view the logs of a particular Docker container, you can run `docker logs crossfeed_worker_cisa_censys_8358453` .
 
 ## ScanTask
 
@@ -51,23 +51,12 @@ You can view the most recent Scan Tasks on the organization page:
 
 ### ScanTask status reference
 
-* `created`: model is created
-* `requested`: a request to Fargate has been sent to start the task
-* `started`: the Fargate container has started running the task
-* `finished`: the Fargate container has finished running the task
-* `failed`: any of the steps above have failed
-
-## Fargate vs Lambda
-
-Each scan specifies whether it should run on Fargate or Lambda in the `SCAN_SCHEMA` variable,
-which is defined in `backend/src/api/scans.ts`.
-
-Changing a scan from Fargate to Lambda, or vice versa, does not require any code change of the
-handler itself; it just requires deployment of the appropriate function in the `tasks.yml` file.
-
-Note that currently, although switching a task to Lambda will work, updating the `ScanTask` status
-has not yet been implemented for Lambda tasks. This is why all tasks are using Fargate.
+* `created` : model is created
+* `requested` : a request to Fargate has been sent to start the task
+* `started` : the Fargate container has started running the task
+* `finished` : the Fargate container has finished running the task
+* `failed` : any of the steps above have failed
 
 ## Building Docker images
 
-For more information on how to build and publish the Fargate Docker images, see `backend/README.md`.
+For more information on how to build and publish the Fargate Docker images, see `backend/README.md` .


### PR DESCRIPTION
Remove the "fargate vs lambda" section as it is obsolete (we no longer support lambda scans).