### PR TITLE
Implement retries, error handling for censys ipv4 scan

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1981,6 +1981,11 @@
         "@types/node": "*"
       }
     },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -11820,6 +11825,15 @@
         "p-timeout": "^3.1.0"
       }
     },
+    "p-retry": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      }
+    },
     "p-some": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
@@ -12953,6 +12967,11 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "reusify": {
       "version": "1.0.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "jsonwebtoken": "^8.5.1",
     "openid-client": "^3.15.8",
     "p-queue": "^6.6.0",
+    "p-retry": "^4.2.0",
     "pg": "^8.3.0",
     "portscanner": "^2.2.0",
     "serverless": "^1.75.1",

--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -113,13 +113,9 @@ export const handler = async (commandOptions: CommandOptions) => {
     throw new Error('Chunks not specified.');
   }
 
-  const {
-    data: { results }
-  } = await axios.get(CENSYS_IPV4_ENDPOINT, { auth });
+  const { results } = await got(CENSYS_IPV4_ENDPOINT, { ...auth }).json();
 
-  const {
-    data: { files }
-  } = await axios.get(results.latest.details_url, { auth });
+  const { files } = await got(results.latest.details_url, { ...auth }).json();
 
   const allDomains = await getAllDomains();
 

--- a/backend/src/tasks/test/__snapshots__/censysIpv4.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/censysIpv4.test.ts.snap
@@ -1830,3 +1830,7 @@ on this server.</p>
   },
 ]
 `;
+
+exports[`censys ipv4 http failure should retry: helpers.saveDomainsToDb 1`] = `Array []`;
+
+exports[`censys ipv4 http failure should retry: helpers.saveServicesToDb 1`] = `Array []`;


### PR DESCRIPTION
## 🗣 Description

- Implement exponential retries for the .gz HTTP requests by using the p-retry library. We retry up to 5 times. This is because the `got` library doesn't automatically retry streamed HTTP requests.
- Properly handle errors when downloading .gz files by listening to the "error" event of `downloadStream`
- Use `got` for initial censys ipv4 endpoint and details requests urls, too. When using the promise-based API of `got`, `got` will automatically implement exponential retry for these, while axios does not do so.

## Related issues

Fixes #156