### PR TITLE
Update user name on invite

### DIFF
--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -116,7 +116,7 @@ export const invite = wrapHandler(async (event) => {
       invitePending: true,
       ...body
     });
-  } else {
+  } else if (!user.firstName && !user.lastName) {
     user.firstName = body.firstName;
     user.lastName = body.lastName;
   }

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -116,8 +116,11 @@ export const invite = wrapHandler(async (event) => {
       invitePending: true,
       ...body
     });
-    await User.save(user);
+  } else {
+    user.firstName = body.firstName;
+    user.lastName = body.lastName;
   }
+  await User.save(user);
 
   if (body.organization) {
     // Create approved role if organization supplied

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -84,8 +84,8 @@ describe('user', () => {
       const lastName = 'last name';
       const email = Math.random() + '@crossfeed.cisa.gov';
       const user = await User.create({
-        firstName: '',
-        lastName: '',
+        firstName,
+        lastName,
         email
       }).save();
       await Role.create({
@@ -108,8 +108,8 @@ describe('user', () => {
           })
         )
         .send({
-          firstName,
-          lastName,
+          firstName: 'new first name',
+          lastName: 'new last name',
           email,
           organization: organization2.id,
           organizationAdmin: false
@@ -124,8 +124,6 @@ describe('user', () => {
       expect(response.body.roles[1].role).toEqual('user');
     });
     it('invite existing user by a different organization admin should work, and should modify user name if user name is initially blank', async () => {
-      const firstName = '';
-      const lastName = '';
       const email = Math.random() + '@crossfeed.cisa.gov';
       const user = await User.create({
         firstName: '',
@@ -152,8 +150,8 @@ describe('user', () => {
           })
         )
         .send({
-          firstName,
-          lastName,
+          firstName: 'new first name',
+          lastName: 'new last name',
           email,
           organization: organization2.id,
           organizationAdmin: false
@@ -162,8 +160,8 @@ describe('user', () => {
       expect(response.body.id).toEqual(user.id);
       expect(response.body.email).toEqual(email);
       expect(response.body.invitePending).toEqual(false);
-      expect(response.body.firstName).toEqual('first name');
-      expect(response.body.lastName).toEqual('last name');
+      expect(response.body.firstName).toEqual('new first name');
+      expect(response.body.lastName).toEqual('new last name');
       expect(response.body.roles[1].approved).toEqual(true);
       expect(response.body.roles[1].role).toEqual('user');
     });

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -118,8 +118,8 @@ describe('user', () => {
       expect(response.body.id).toEqual(user.id);
       expect(response.body.email).toEqual(email);
       expect(response.body.invitePending).toEqual(false);
-      expect(response.body.firstName).toEqual('original first name');
-      expect(response.body.lastName).toEqual('original last name');
+      expect(response.body.firstName).toEqual('first name');
+      expect(response.body.lastName).toEqual('last name');
       expect(response.body.roles[1].approved).toEqual(true);
       expect(response.body.roles[1].role).toEqual('user');
     });

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -79,7 +79,7 @@ describe('user', () => {
       expect(response.body.roles[0].approved).toEqual(true);
       expect(response.body.roles[0].role).toEqual('user');
     });
-    it('invite existing user by a different organization admin should work, and should not modify other user details', async () => {
+    it('invite existing user by a different organization admin should work, and should modify other user details', async () => {
       const firstName = 'first name';
       const lastName = 'last name';
       const email = Math.random() + '@crossfeed.cisa.gov';

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -79,7 +79,7 @@ describe('user', () => {
       expect(response.body.roles[0].approved).toEqual(true);
       expect(response.body.roles[0].role).toEqual('user');
     });
-    it('invite existing user by a different organization admin should work, and should modify other user details', async () => {
+    it('invite existing user by a different organization admin should work, and should modify user name, but not any other details', async () => {
       const firstName = 'first name';
       const lastName = 'last name';
       const email = Math.random() + '@crossfeed.cisa.gov';

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -84,8 +84,8 @@ describe('user', () => {
       const lastName = 'last name';
       const email = Math.random() + '@crossfeed.cisa.gov';
       const user = await User.create({
-        firstName: 'original first name',
-        lastName: 'original last name',
+        firstName: '',
+        lastName: '',
         email
       }).save();
       await Role.create({

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -79,9 +79,53 @@ describe('user', () => {
       expect(response.body.roles[0].approved).toEqual(true);
       expect(response.body.roles[0].role).toEqual('user');
     });
-    it('invite existing user by a different organization admin should work, and should modify user name, but not any other details', async () => {
+    it('invite existing user by a different organization admin should work, and should not modify other user details', async () => {
       const firstName = 'first name';
       const lastName = 'last name';
+      const email = Math.random() + '@crossfeed.cisa.gov';
+      const user = await User.create({
+        firstName: '',
+        lastName: '',
+        email
+      }).save();
+      await Role.create({
+        role: 'user',
+        approved: false,
+        organization,
+        user
+      }).save();
+      const response = await request(app)
+        .post('/users')
+        .set(
+          'Authorization',
+          createUserToken({
+            roles: [
+              {
+                org: organization2.id,
+                role: 'admin'
+              }
+            ]
+          })
+        )
+        .send({
+          firstName,
+          lastName,
+          email,
+          organization: organization2.id,
+          organizationAdmin: false
+        })
+        .expect(200);
+      expect(response.body.id).toEqual(user.id);
+      expect(response.body.email).toEqual(email);
+      expect(response.body.invitePending).toEqual(false);
+      expect(response.body.firstName).toEqual('first name');
+      expect(response.body.lastName).toEqual('last name');
+      expect(response.body.roles[1].approved).toEqual(true);
+      expect(response.body.roles[1].role).toEqual('user');
+    });
+    it('invite existing user by a different organization admin should work, and should modify user name if user name is initially blank', async () => {
+      const firstName = '';
+      const lastName = '';
       const email = Math.random() + '@crossfeed.cisa.gov';
       const user = await User.create({
         firstName: '',


### PR DESCRIPTION
This PR updates a user's name on invite, if their account already exists. This is helpful when users are invited after an account is created, as their name is initially blank.