### PR TITLE
Set onUpdate: 'CASCADE' for scan -> scantasks relationship

### DIFF
--- a/backend/src/models/scan-task.ts
+++ b/backend/src/models/scan-task.ts
@@ -29,7 +29,7 @@ export class ScanTask extends BaseEntity {
 
   @ManyToOne((type) => Scan, (scan) => scan.scanTasks, {
     onDelete: 'SET NULL',
-    onUpdate: 'SET NULL'
+    onUpdate: 'CASCADE'
   })
   @JoinColumn()
   scan: Scan;


### PR DESCRIPTION
I don't think `onUpdate: 'SET NULL'` makes any sense.