### PR TITLE
Don't delete scantasks when a scan is deleted

### DIFF
--- a/backend/src/models/scan.ts
+++ b/backend/src/models/scan.ts
@@ -37,7 +37,7 @@ export class Scan extends BaseEntity {
   lastRun: Date | null;
 
   @OneToMany((type) => ScanTask, (scanTask) => scanTask.scan, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
     onUpdate: 'CASCADE'
   })
   scanTasks: ScanTask[];


### PR DESCRIPTION
This is because we always want to preserve the history of scantasks run.