### PR TITLE
Censys ipv4 fixes

### DIFF
--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -51,6 +51,7 @@ const downloadPath = async (
         // For local development: just randomly match domains
         // (this behavior is not present when running tests
         // through jest, though).
+        // eslint-disable-next-line prefer-spread
         matchingDomains = [].concat
           .apply([], Object.values(ipToDomainsMap)) // get a list of all domains in the domain map
           .filter(() => Math.random() < 0.00001);

--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -46,15 +46,14 @@ const downloadPath = async (
     readInterface.on('line', function (line) {
       const item: CensysIpv4Data = JSON.parse(line);
 
-      const matchingDomains = ipToDomainsMap[item.ip!] || [];
+      let matchingDomains = ipToDomainsMap[item.ip!] || [];
       if (process.env.IS_LOCAL && typeof jest === 'undefined') {
         // For local development: just randomly match domains
         // (this behavior is not present when running tests
         // through jest, though).
-        const matchingDomainsArr = Object.values(ipToDomainsMap) // get a list of all domains in the domain map
+        matchingDomains = [].concat
+          .apply([], Object.values(ipToDomainsMap)) // get a list of all domains in the domain map
           .filter(() => Math.random() < 0.00001);
-        for (const domain of matchingDomainsArr)
-          matchingDomains.concat(...domain);
       }
       for (const matchingDomain of matchingDomains) {
         domains.push(

--- a/frontend/src/components/ServicesTable/ServicesTable.tsx
+++ b/frontend/src/components/ServicesTable/ServicesTable.tsx
@@ -14,28 +14,31 @@ const CodeBlock: React.FC<{}> = ({ children }) => {
 };
 
 export const ServicesTable: React.FC<Props> = ({ services }) => {
-  const renderExpanded = useCallback((row: Row<Service>) => {
-    const { original } = row;
-    return (
-      <div className={classes.expandedRoot}>
-        {original.banner && (
-          <>
-            <h4>Banner</h4>
-            <CodeBlock>{original.banner}</CodeBlock>
-          </>
-        )}
-        {original.censysIpv4Results &&
-          Object.keys(original.censysIpv4Results)?.length === 0 && (
+  const renderExpanded = useCallback(
+    (row: Row<Service>) => {
+      const { original } = row;
+      return (
+        <div className={classes.expandedRoot}>
+          {original.banner && (
             <>
-              <h4>Censys IPv4 Results</h4>
-              <CodeBlock>
-                {JSON.stringify(original.censysIpv4Results, null, 2)}
-              </CodeBlock>
+              <h4>Banner</h4>
+              <CodeBlock>{original.banner}</CodeBlock>
             </>
           )}
-      </div>
-    );
-  }, []);
+          {original.censysIpv4Results &&
+            Object.keys(original.censysIpv4Results)?.length > 0 && (
+              <>
+                <h4>Censys IPv4 Results</h4>
+                <CodeBlock>
+                  {JSON.stringify(original.censysIpv4Results, null, 2)}
+                </CodeBlock>
+              </>
+            )}
+        </div>
+      );
+    },
+    [classes]
+  );
 
   return (
     <Table<Service>

--- a/frontend/src/components/ServicesTable/ServicesTable.tsx
+++ b/frontend/src/components/ServicesTable/ServicesTable.tsx
@@ -14,31 +14,28 @@ const CodeBlock: React.FC<{}> = ({ children }) => {
 };
 
 export const ServicesTable: React.FC<Props> = ({ services }) => {
-  const renderExpanded = useCallback(
-    (row: Row<Service>) => {
-      const { original } = row;
-      return (
-        <div className={classes.expandedRoot}>
-          {original.banner && (
+  const renderExpanded = useCallback((row: Row<Service>) => {
+    const { original } = row;
+    return (
+      <div className={classes.expandedRoot}>
+        {original.banner && (
+          <>
+            <h4>Banner</h4>
+            <CodeBlock>{original.banner}</CodeBlock>
+          </>
+        )}
+        {original.censysIpv4Results &&
+          Object.keys(original.censysIpv4Results)?.length > 0 && (
             <>
-              <h4>Banner</h4>
-              <CodeBlock>{original.banner}</CodeBlock>
+              <h4>Censys IPv4 Results</h4>
+              <CodeBlock>
+                {JSON.stringify(original.censysIpv4Results, null, 2)}
+              </CodeBlock>
             </>
           )}
-          {original.censysIpv4Results &&
-            Object.keys(original.censysIpv4Results)?.length > 0 && (
-              <>
-                <h4>Censys IPv4 Results</h4>
-                <CodeBlock>
-                  {JSON.stringify(original.censysIpv4Results, null, 2)}
-                </CodeBlock>
-              </>
-            )}
-        </div>
-      );
-    },
-    [classes]
-  );
+      </div>
+    );
+  }, []);
 
   return (
     <Table<Service>


### PR DESCRIPTION
- Show full censys results in the services description. Fixes #188

![image](https://user-images.githubusercontent.com/1689183/89125599-a0c64300-d4ad-11ea-9b17-4312e49e80ce.png)


- Let censys ipv4 scan dummy data work again on localhost. I think the change you made to the code @cablej essentially made it so that it would get nearly zero results.