### PR TITLE
Rename "Global Scans" -> "All Scans" in navbar

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -141,7 +141,7 @@ export const Header: React.FC = () => {
       key="scans"
       className="usa-nav__link"
     >
-      <span>Global Scans</span>
+      <span>All Scans</span>
     </NavLink>,
     <NavLink
       activeClassName="usa-current"


### PR DESCRIPTION
This way, we won't confuse this with the actual `global` property of the scan schema.