### PR TITLE
Fix scheduling logic for CensysIpv4

### DIFF
--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -130,7 +130,7 @@ const shouldRunScan = async ({
       }
     }
   );
-  if (lastRunningScanTask && !lastFinishedScanTask) {
+  if (lastRunningScanTask) {
     // Don't run another task if there's already a running task.
     return false;
   }

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -118,6 +118,10 @@ const shouldRunScan = async ({
       }
     }
   );
+  if (lastRunningScanTask) {
+    // Don't run another task if there's already a running task.
+    return false;
+  }
   const lastFinishedScanTask = await ScanTask.findOne(
     {
       scan: { id: scan.id },
@@ -130,10 +134,6 @@ const shouldRunScan = async ({
       }
     }
   );
-  if (lastRunningScanTask) {
-    // Don't run another task if there's already a running task.
-    return false;
-  }
   if (
     lastFinishedScanTask &&
     lastFinishedScanTask.finishedAt &&

--- a/backend/src/tasks/test/scheduler.test.ts
+++ b/backend/src/tasks/test/scheduler.test.ts
@@ -265,19 +265,19 @@ describe('scheduler', () => {
       scan,
       type: 'fargate',
       status: 'finished',
-      createdAt: "2000-08-03T13:58:31.634Z"
+      createdAt: '2000-08-03T13:58:31.634Z'
     }).save();
     await ScanTask.create({
       scan,
       type: 'fargate',
       status: 'created',
-      createdAt: "2000-05-03T13:58:31.634Z"
+      createdAt: '2000-05-03T13:58:31.634Z'
     }).save();
     await ScanTask.create({
       scan,
       type: 'fargate',
       status: 'finished',
-      createdAt: "2000-01-03T13:58:31.634Z"
+      createdAt: '2000-01-03T13:58:31.634Z'
     }).save();
 
     await scheduler(

--- a/backend/src/tasks/test/scheduler.test.ts
+++ b/backend/src/tasks/test/scheduler.test.ts
@@ -255,4 +255,39 @@ describe('scheduler', () => {
 
     expect(runCommand).toHaveBeenCalledTimes(0);
   });
+  test('should not run a global scan when a scantask for it is already in progress, even if scantasks have finished before / after it', async () => {
+    const scan = await Scan.create({
+      name: 'censysIpv4',
+      arguments: {},
+      frequency: 999
+    }).save();
+    await ScanTask.create({
+      scan,
+      type: 'fargate',
+      status: 'finished',
+      createdAt: "2000-08-03T13:58:31.634Z"
+    }).save();
+    await ScanTask.create({
+      scan,
+      type: 'fargate',
+      status: 'created',
+      createdAt: "2000-05-03T13:58:31.634Z"
+    }).save();
+    await ScanTask.create({
+      scan,
+      type: 'fargate',
+      status: 'finished',
+      createdAt: "2000-01-03T13:58:31.634Z"
+    }).save();
+
+    await scheduler(
+      {
+        scanId: scan.id
+      },
+      {} as any,
+      () => void 0
+    );
+
+    expect(runCommand).toHaveBeenCalledTimes(0);
+  });
 });


### PR DESCRIPTION
## 🗣 Description

Fixes scheduling logic so that if _any_ task is already running, the scheduler will not schedule a new task. This fixes the issue in which too many tasks were launched by CensysIpv4, because as soon as one chunk (out of 20) had finished, the scheduler would end up launching more tasks (when it really needs to wait until all 20 tasks have finished).

Fixes #195.