### PR TITLE
Add a code coverage CI check for backend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -86,7 +86,7 @@ jobs:
         run: docker-compose exec -T backend npx sls invoke local -f syncdb -d dangerouslyforce
         working-directory: ./
       - name: Test
-        run: npm run test
+        run: npm run test -- --collectCoverage
   build_worker:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -11,5 +11,14 @@ module.exports = {
   testEnvironment: 'node',
   modulePathIgnorePatterns: ['<rootDir>/.build/'],
   globalSetup: '<rootDir>/test/setup.ts',
-  clearMocks: true
+  clearMocks: true,
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '.*report.*' // Remove this when we enable report / vulnerability functionality
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 50
+    }
+  }
 };

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -51,6 +51,10 @@ npm test
 
 To update snapshots, run `npm test -- -u`.
 
+To view a code coverage report (a minimum code coverage threshold is checked in CI), run `npm test -- --collectCoverage`.
+
+You can then view a HTML coverage report in the `coverage/lcov-report` directory.
+
 ## Fargate worker
 
 In order to run scans locally or work on scanning infrastructure,


### PR DESCRIPTION
Collect code coverage on the backend -- this way we can enforce that any additional changes will have some level of tests added to them. I've added a conservative threshold, 50% branch coverage (right now we're a few points above that).

It also generates nice HTML reports that look like this:

![image](https://user-images.githubusercontent.com/1689183/89536913-8b5f5a80-d7c6-11ea-9a93-a16ab6bc28ed.png)
