### PR TITLE
Add npm shortcuts for running syncdb and scheduler

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -63,7 +63,9 @@
     "preinstall": "npx npm-force-resolutions",
     "codegen": "ts-node src/tools/generate-censys-types.ts",
     "build-worker": "./tools/build-worker.sh",
-    "deploy-worker": "./tools/deploy-worker.sh"
+    "deploy-worker": "./tools/deploy-worker.sh",
+    "syncdb": "docker-compose exec backend npx sls invoke local -f syncdb",
+    "scheduler": "docker-compose exec scheduler npx sls invoke local -f scheduler"
   },
   "author": "",
   "license": "ISC"

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -22,9 +22,8 @@ subnav:
 1.  Start entire environment from root using Docker Compose
     - `docker-compose up --build`
 1.  Generate DB schema:
-
-    - `docker-compose exec backend npx sls invoke local -f syncdb`
-    - (append `-d dangerouslyforce` to drop and recreate)
+    - `cd backend && npm run syncdb`
+    - (run `npm run syncdb -- -d dangerouslyforce` to drop and recreate)
 
 1.  Navigate to [localhost](http://localhost) in a browser.
 
@@ -38,11 +37,11 @@ subnav:
 
 The scheduler lambda function is set to run on an interval or in response to non-http events. To run it manually, run the following command:
 
-- `docker-compose exec scheduler npx serverless invoke local -f scheduler`
+- `cd backend && npm run scheduler`
 
 ### Running tests
 
-To run tests, first make sure you have already started crossfeed with `docker-compose` . Then run:
+To run tests, first make sure you have already started crossfeed with `docker-compose`. Then run:
 
 ```bash
 cd backend


### PR DESCRIPTION
Add npm shortcuts for running syncdb and scheduler. Taking this change out of #196.