### PR TITLE
Add an organization filter to domains / vulnerabilities

### DIFF
--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -6,7 +6,8 @@ import {
   ValidateNested,
   isUUID,
   IsOptional,
-  IsObject
+  IsObject,
+  IsUUID
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { Domain, connectToDatabase } from '../models';
@@ -32,6 +33,10 @@ class DomainFilters {
   @IsString()
   @IsOptional()
   ip?: string;
+
+  @IsUUID()
+  @IsOptional()
+  organization?: string;
 }
 
 class DomainSearch {
@@ -78,6 +83,11 @@ class DomainSearch {
         { service: `%${this.filters?.service}%` }
       );
     }
+    if (this.filters?.organization) {
+      qs.andWhere('domain.organization IN (:...orgs)', {
+        orgs: [this.filters.organization]
+      });
+    }
     return qs;
   }
 
@@ -122,6 +132,11 @@ class DomainSearch {
     if (this.filters?.service) {
       qs.andWhere('services.service ILIKE :service', {
         service: `%${this.filters?.service}%`
+      });
+    }
+    if (this.filters?.organization) {
+      qs.andWhere('domain.organization IN (:...orgs)', {
+        orgs: [this.filters.organization]
       });
     }
   }

--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -84,8 +84,8 @@ class DomainSearch {
       );
     }
     if (this.filters?.organization) {
-      qs.andWhere('domain.organization IN (:...orgs)', {
-        orgs: [this.filters.organization]
+      qs.andWhere('domain.organization = :org', {
+        org: this.filters.organization
       });
     }
     return qs;

--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -135,8 +135,8 @@ class DomainSearch {
       });
     }
     if (this.filters?.organization) {
-      qs.andWhere('domain.organization IN (:...orgs)', {
-        orgs: [this.filters.organization]
+      qs.andWhere('domain.organization = :org', {
+        org: this.filters.organization
       });
     }
   }

--- a/backend/src/api/vulnerabilities.ts
+++ b/backend/src/api/vulnerabilities.ts
@@ -96,8 +96,8 @@ class VulnerabilitySearch {
       });
     }
     if (this.filters?.organization) {
-      qs.andWhere('organization.id IN (:...orgs)', {
-        orgs: [this.filters.organization]
+      qs.andWhere('organization.id = :org', {
+        org: this.filters.organization
       });
     }
     return qs;

--- a/backend/src/api/vulnerabilities.ts
+++ b/backend/src/api/vulnerabilities.ts
@@ -38,6 +38,10 @@ class VulnerabilityFilters {
   @IsString()
   @IsOptional()
   state?: string;
+
+  @IsUUID()
+  @IsOptional()
+  organization?: string;
 }
 
 class VulnerabilitySearch {
@@ -89,6 +93,11 @@ class VulnerabilitySearch {
     if (this.filters?.state) {
       qs.andWhere('vulnerability.state=:state', {
         state: this.filters.state
+      });
+    }
+    if (this.filters?.organization) {
+      qs.andWhere('organization.id IN (:...orgs)', {
+        orgs: [this.filters.organization]
       });
     }
     return qs;

--- a/backend/test/domains.test.ts
+++ b/backend/test/domains.test.ts
@@ -67,7 +67,7 @@ describe('domains', () => {
       expect(response.body.count).toEqual(2);
     });
     it('list by globalView with org filter should only return domains from that org', async () => {
-      let organization = await Organization.create({
+      const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],
         ipBlocks: [],


### PR DESCRIPTION
Fixes #238 so that when passing in `organization` as a filter, it properly filters domains / vulnerabilities shown.