### PR TITLE
Prevent non-static assets from being cached by cloudfront

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -111,14 +111,14 @@ jobs:
 
       - name: Deploy Staging
         if: github.ref == 'refs/heads/master'
-        run: aws s3 sync build s3://staging.crossfeed.cyber.dhs.gov
+        run: aws s3 sync build s3://staging.crossfeed.cyber.dhs.gov --delete
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
       - name: Deploy Production
         if: github.ref == 'refs/heads/production'
-        run: aws s3 sync build s3://crossfeed.cyber.dhs.gov
+        run: aws s3 sync build s3://crossfeed.cyber.dhs.gov --delete
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -111,26 +111,14 @@ jobs:
 
       - name: Deploy Staging
         if: github.ref == 'refs/heads/master'
-        run: |
-          aws s3 sync \
-            --cache-control 'max-age=2628000' \
-            build/static s3://staging.crossfeed.cyber.dhs.gov
-          aws s3 sync \
-            --cache-control 'no-cache' \
-            build s3://staging.crossfeed.cyber.dhs.gov
+        run: aws s3 sync build s3://staging.crossfeed.cyber.dhs.gov
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
       - name: Deploy Production
         if: github.ref == 'refs/heads/production'
-        run: |
-          aws s3 sync \
-            --cache-control 'max-age=2628000' \
-            build/static s3://crossfeed.cyber.dhs.gov
-          aws s3 sync \
-            --cache-control 'no-cache' \
-            build s3://crossfeed.cyber.dhs.gov
+        run: aws s3 sync build s3://crossfeed.cyber.dhs.gov
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -111,35 +111,26 @@ jobs:
 
       - name: Deploy Staging
         if: github.ref == 'refs/heads/master'
-        run: aws s3 sync build/ s3://staging.crossfeed.cyber.dhs.gov/ --delete
+        run: |
+          aws s3 sync \
+            --cache-control 'max-age=2628000' \
+            build/static s3://staging.crossfeed.cyber.dhs.gov
+          aws s3 sync \
+            --cache-control 'no-cache' \
+            build s3://staging.crossfeed.cyber.dhs.gov
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
       - name: Deploy Production
         if: github.ref == 'refs/heads/production'
-        run: aws s3 sync build/ s3://crossfeed.cyber.dhs.gov/ --delete
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-
-      - name: Invalidate Old Cache - Staging
-        if: github.ref == 'refs/heads/master'
-        run: aws cloudfront create-invalidation --distribution-id ELM2YU1N4NV9M --paths "/index.html"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-
-      - name: Invalidate Old Cache - Production
-        if: github.ref == 'refs/heads/production'
-        run: aws cloudfront create-invalidation --distribution-id E1L9ZZ6QDXV2NQ --paths "/index.html"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-
-      - name: Invalidate Old Cache - Production
-        if: github.ref == 'refs/heads/production'
-        run: aws cloudfront create-invalidation --distribution-id E3F1VQXKJQD68D --paths "/index.html"
+        run: |
+          aws s3 sync \
+            --cache-control 'max-age=2628000' \
+            build/static s3://crossfeed.cyber.dhs.gov
+          aws s3 sync \
+            --cache-control 'no-cache' \
+            build s3://crossfeed.cyber.dhs.gov
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/infrastructure/frontend.tf
+++ b/infrastructure/frontend.tf
@@ -53,8 +53,28 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = 0
+    max_ttl                = 0
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/static/*"
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 2628000
+    max_ttl                = 2628000
   }
 
   tags = {	


### PR DESCRIPTION
## 🗣 Description

This is in relation to #158.

Following the guidence for create-react-app [here](https://create-react-app.dev/docs/production-build/), this will:
- Cache all assets under build/static for a month, they are named using hashes during the CRA build process and will be unique for each build
- Don't cache anything else, includes `index.html`, `robots.txt`, etc
- Most recent `index.html` will always be fetched, which will contain references to most recent static assets from the build. 

@epicfaace I think this is what you meant. I don't think a cloudfront invalidation is necessary since it should respect the `cache-control` header from s3.


## 💭 Motivation and Context

More seamless frontend deploys

## 🧪 Testing

Verify Caching behavior in s3/cloudfront on deploy to staging.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
