### PR TITLE
Fix domain page for undefined orgs

### DIFF
--- a/frontend/src/pages/Domain/Domain.tsx
+++ b/frontend/src/pages/Domain/Domain.tsx
@@ -125,7 +125,7 @@ export const Domain: React.FC = () => {
                     <FaBuilding />
                     Organization
                   </label>
-                  <span>{domain.organization.name}</span>
+                  <span>{domain.organization?.name}</span>
                 </div>
 
                 <div className={classes.headerRow}>
@@ -133,7 +133,7 @@ export const Domain: React.FC = () => {
                     <FaClock />
                     Passive Mode
                   </label>
-                  <span>{domain.organization.isPassive ? 'Yes' : 'No'}</span>
+                  <span>{domain.organization?.isPassive ? 'Yes' : 'No'}</span>
                 </div>
               </div>
               <div className={classes.imgWrapper}>


### PR DESCRIPTION
Fixes #265. Now, the page will just be blank next to "organization":

![image](https://user-images.githubusercontent.com/1689183/90270253-e5e06280-de27-11ea-91db-32c45eb8e118.png)
