### PR TITLE
Increase memory / CPU for cve scans

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -87,6 +87,8 @@ export const SCAN_SCHEMA: ScanSchema = {
     type: 'fargate',
     isPassive: true,
     global: true,
+    cpu: '1024',
+    memory: '4096',
     description: 'Matches detected software versions to CVEs from NIST NVD'
   }
 };


### PR DESCRIPTION
Fixes #248 -- "Killed" comes when the process takes up too much memory.

I initially tried to use `exec` instead to return a stream for stdout, but that still had the same problem, so increasing the memory was enough to fix it.

I've deployed this worker to staging and confirmed that it works fine (see https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/crossfeed-staging-worker/log-events/worker$252Fmain$252Fc6727e56-00d9-4d32-9bcd-605580ba7e51).