### PR TITLE
Fix log links locally

### DIFF
--- a/frontend/src/pages/Scans/ScanTasksView.tsx
+++ b/frontend/src/pages/Scans/ScanTasksView.tsx
@@ -121,7 +121,7 @@ export const ScanTasksView: React.FC = () => {
       id: 'actions',
       Cell: ({ row }: CellProps<ScanTask>) => (
         <>
-          {row.original.fargateTaskArn && (
+          {row.original.fargateTaskArn && row.original.fargateTaskArn.match('/(.*)') && (
             <>
               <a
                 target="_blank"


### PR DESCRIPTION
Previously, trying to view the scantasks table when running locally would give an error because `row.original.fargateTaskArn.match('/(.*)')` evaluates to undefined / null.