### PR TITLE
Set reservedConcurrency of scheduler to 1

### DIFF
--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -2,7 +2,7 @@ scheduler:
   handler: src/tasks/scheduler.handler
   timeout: 300
   events:
-    - schedule: rate(1 minute)
+    - schedule: rate(5 minutes)
   reservedConcurrency: 1
 
 syncdb:


### PR DESCRIPTION
This way, more than one scheduler function cannot run at once.

This will also allow us for someone to click a "run scheduler" button on demand without any worries about functions interfering with each other (see #299).

See https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html#configuration-concurrency-reserved

Trying to run the scheduler function once another scheduler function has been run will give an error:

![image](https://user-images.githubusercontent.com/1689183/90965527-da7bdf80-e496-11ea-9faf-a4a0135da823.png)
