### PR TITLE
Add provisioned concurrency to lambda function

### DIFF
--- a/backend/src/api/functions.yml
+++ b/backend/src/api/functions.yml
@@ -9,3 +9,4 @@ api:
         path: /{any+} # this matches any path, the token 'any' doesn't mean anything special
         method: ANY
         cors: true
+  provisionedConcurrency: 1


### PR DESCRIPTION
This PR adds provisioned concurrency to the API Lambda function, which should allow for lower latency when a first request in a while is being made.