### PR TITLE
Use prod fargate worker name when needed

### DIFF
--- a/backend/env.yml
+++ b/backend/env.yml
@@ -35,6 +35,8 @@ staging:
   DOMAIN: ${ssm:/crossfeed/staging/DOMAIN}
   FARGATE_SG_ID: ${ssm:/crossfeed/staging/WORKER_SG_ID}
   FARGATE_SUBNET_ID: ${ssm:/crossfeed/staging/WORKER_SUBNET_ID}
+  FARGATE_CLUSTER_NAME: 'crossfeed-staging-worker'
+  FARGATE_TASK_DEFINITION_NAME: 'crossfeed-staging-worker'
   CROSSFEED_SUPPORT_EMAIL: 'support@staging.crossfeed.cyber.dhs.gov'
   FRONTEND_DOMAIN: 'https://staging.crossfeed.cyber.dhs.gov'
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'
@@ -55,6 +57,8 @@ prod:
   DOMAIN: ${ssm:/crossfeed/prod/DOMAIN}
   FARGATE_SG_ID: ${ssm:/crossfeed/prod/WORKER_SG_ID}
   FARGATE_SUBNET_ID: ${ssm:/crossfeed/prod/WORKER_SUBNET_ID}
+  FARGATE_CLUSTER_NAME: 'crossfeed-prod-worker'
+  FARGATE_TASK_DEFINITION_NAME: 'crossfeed-prod-worker'
   CROSSFEED_SUPPORT_EMAIL: 'support@crossfeed.cyber.dhs.gov'
   FRONTEND_DOMAIN: 'https://crossfeed.cyber.dhs.gov'
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'

--- a/backend/src/tasks/ecs-client.ts
+++ b/backend/src/tasks/ecs-client.ts
@@ -125,10 +125,9 @@ class ECSClient {
         value: String(chunkNumber)
       });
     }
-    // TODO: retrieve these values from SSM.
     return this.ecs!.runTask({
-      cluster: 'crossfeed-staging-worker', // aws_ecs_cluster.worker.name
-      taskDefinition: 'crossfeed-staging-worker', // aws_ecs_task_definition.worker.name
+      cluster: process.env.FARGATE_CLUSTER_NAME!,
+      taskDefinition: process.env.FARGATE_TASK_DEFINITION_NAME!,
       networkConfiguration: {
         awsvpcConfiguration: {
           assignPublicIp: 'ENABLED',


### PR DESCRIPTION
This way, "crossfeed-staging-worker" is not hardcoded.

We should eventually retrieve this value from SSM, but this PR should be enough for initial deployment to prod.