### PR TITLE
Scan bug fixes

### DIFF
--- a/backend/src/tasks/amass.ts
+++ b/backend/src/tasks/amass.ts
@@ -17,34 +17,39 @@ export const handler = async (commandOptions: CommandOptions) => {
   const rootDomains = await getRootDomains(organizationId!);
 
   for (const rootDomain of rootDomains) {
-    const args = [
-      'enum',
-      '-ip',
-      '-active',
-      '-d',
-      rootDomain,
-      '-json',
-      OUT_PATH
-    ];
-    console.log('Running amass with args', args);
-    spawnSync('amass', args, { stdio: 'pipe' });
+    try {
+      const args = [
+        'enum',
+        '-ip',
+        '-active',
+        '-d',
+        rootDomain,
+        '-json',
+        OUT_PATH
+      ];
+      console.log('Running amass with args', args);
+      spawnSync('amass', args, { stdio: 'pipe' });
 
-    const output = String(readFileSync(OUT_PATH));
-    const lines = output.split('\n');
-    const domains: Domain[] = [];
-    for (const line of lines) {
-      if (line == '') continue;
-      const parsed = JSON.parse(line);
-      domains.push(
-        plainToClass(Domain, {
-          ip: parsed.addresses[0].ip,
-          name: parsed.name,
-          asn: parsed.addresses[0].asn,
-          organization: { id: organizationId }
-        })
-      );
+      const output = String(readFileSync(OUT_PATH));
+      const lines = output.split('\n');
+      const domains: Domain[] = [];
+      for (const line of lines) {
+        if (line == '') continue;
+        const parsed = JSON.parse(line);
+        domains.push(
+          plainToClass(Domain, {
+            ip: parsed.addresses[0].ip,
+            name: parsed.name,
+            asn: parsed.addresses[0].asn,
+            organization: { id: organizationId }
+          })
+        );
+      }
+      await saveDomainsToDb(domains);
+      console.log(`amass created/updated ${domains.length} new domains`);
+    } catch (e) {
+      console.error(e);
+      continue;
     }
-    await saveDomainsToDb(domains);
-    console.log(`amass created/updated ${domains.length} new domains`);
   }
 };

--- a/backend/src/tasks/findomain.ts
+++ b/backend/src/tasks/findomain.ts
@@ -17,25 +17,30 @@ export const handler = async (commandOptions: CommandOptions) => {
   const rootDomains = await getRootDomains(organizationId!);
 
   for (const rootDomain of rootDomains) {
-    const args = ['-it', rootDomain, '-u', OUT_PATH];
-    console.log('Running findomain with args', args);
-    spawnSync('findomain', args, { stdio: 'pipe' });
+    try {
+      const args = ['-it', rootDomain, '-u', OUT_PATH];
+      console.log('Running findomain with args', args);
+      spawnSync('findomain', args, { stdio: 'pipe' });
 
-    const output = String(readFileSync(OUT_PATH));
-    const lines = output.split('\n');
-    const domains: Domain[] = [];
-    for (const line of lines) {
-      if (line == '') continue;
-      const split = line.split(',');
-      domains.push(
-        plainToClass(Domain, {
-          name: split[0],
-          ip: split[1],
-          organization: { id: organizationId }
-        })
-      );
+      const output = String(readFileSync(OUT_PATH));
+      const lines = output.split('\n');
+      const domains: Domain[] = [];
+      for (const line of lines) {
+        if (line == '') continue;
+        const split = line.split(',');
+        domains.push(
+          plainToClass(Domain, {
+            name: split[0],
+            ip: split[1],
+            organization: { id: organizationId }
+          })
+        );
+      }
+      await saveDomainsToDb(domains);
+      console.log(`Findomain created/updated ${domains.length} new domains`);
+    } catch (e) {
+      console.error(e);
+      continue;
     }
-    await saveDomainsToDb(domains);
-    console.log(`Findomain created/updated ${domains.length} new domains`);
   }
 };

--- a/backend/src/tasks/portscanner.ts
+++ b/backend/src/tasks/portscanner.ts
@@ -18,15 +18,20 @@ export const handler = async (commandOptions: CommandOptions) => {
   const services: Service[] = [];
   for (const domain of domainsWithIPs) {
     for (const port of [21, 22, 80, 443, 3000, 8080, 8443]) {
-      const status = await portscanner.checkPortStatus(port, domain.ip);
-      if (status === 'open') {
-        services.push(
-          plainToClass(Service, {
-            domain: domain,
-            port: port,
-            lastSeen: new Date(Date.now())
-          })
-        );
+      try {
+        const status = await portscanner.checkPortStatus(port, domain.ip);
+        if (status === 'open') {
+          services.push(
+            plainToClass(Service, {
+              domain: domain,
+              port: port,
+              lastSeen: new Date(Date.now())
+            })
+          );
+        }
+      } catch (e) {
+        console.error(e);
+        continue;
       }
     }
   }

--- a/backend/src/tasks/test/wappalyzer.test.ts
+++ b/backend/src/tasks/test/wappalyzer.test.ts
@@ -4,16 +4,12 @@ import * as wappalyzer from 'simple-wappalyzer';
 import { Domain, Service } from '../../models';
 import { CommandOptions } from '../ecs-client';
 import { handler } from '../wappalyzer';
-import saveDomainsToDb from '../helpers/saveDomainsToDb';
 import * as nock from 'nock';
 
 const wappalyzer = require('simple-wappalyzer');
 
 jest.mock('../helpers/getLiveWebsites');
 const getLiveWebsitesMock = mocked(getLiveWebsites);
-
-jest.mock('../helpers/saveDomainsToDb');
-const saveDomainsToDbMock = mocked(saveDomainsToDb);
 
 // @ts-ignore
 jest.mock('simple-wappalyzer', () => jest.fn());
@@ -51,10 +47,6 @@ const commandOptions: CommandOptions = {
 describe('wappalyzer', () => {
   let testDomain: Domain;
 
-  beforeAll(() => {
-    saveDomainsToDbMock.mockResolvedValue();
-  });
-
   beforeEach(() => {
     testDomain = new Domain();
     testDomain.name = 'example.com';
@@ -67,7 +59,6 @@ describe('wappalyzer', () => {
   afterEach(() => {
     getLiveWebsitesMock.mockReset();
     wappalyzer.mockReset();
-    saveDomainsToDbMock.mockReset();
     nock.cleanAll();
   });
 
@@ -139,11 +130,8 @@ describe('wappalyzer', () => {
     await handler(commandOptions);
     scope.done();
     expect(wappalyzer).toHaveBeenCalledTimes(2);
-    expect(saveDomainsToDbMock).toHaveBeenCalledTimes(1);
-    // only the domain with results was saved
-    expect(saveDomainsToDbMock.mock.calls).toHaveLength(1);
     expect(logSpy).toHaveBeenLastCalledWith(
-      'Wappalyzer finished for 1 domains'
+      'Wappalyzer finished for 2 domains'
     );
   });
 

--- a/backend/src/tasks/wappalyzer.ts
+++ b/backend/src/tasks/wappalyzer.ts
@@ -1,13 +1,11 @@
 import { Domain } from '../models';
-import { plainToClass } from 'class-transformer';
 import * as wappalyzer from 'simple-wappalyzer';
 import axios from 'axios';
 import { CommandOptions } from './ecs-client';
 import getLiveWebsites from './helpers/getLiveWebsites';
-import saveDomainsToDb from './helpers/saveDomainsToDb';
 import PQueue from 'p-queue';
 
-const wappalyze = async (domain: Domain): Promise<Domain | undefined> => {
+const wappalyze = async (domain: Domain): Promise<void> => {
   const ports = domain.services.map((service) => service.port);
   const url = ports.includes(443)
     ? `https://${domain.name}`
@@ -18,18 +16,12 @@ const wappalyze = async (domain: Domain): Promise<Domain | undefined> => {
     });
     const result = await wappalyzer({ url, data, status, headers });
     if (result.length > 0) {
-      return plainToClass(Domain, {
-        name: domain.name,
-        webTechnologies: result
-      });
+      domain.webTechnologies = result;
+      await domain.save();
     }
   } catch (e) {
     console.error(e);
   }
-};
-
-const filterEmpty = <T>(value: T | undefined | null): value is T => {
-  return value !== null && value !== undefined;
 };
 
 export const handler = async (commandOptions: CommandOptions) => {
@@ -39,11 +31,9 @@ export const handler = async (commandOptions: CommandOptions) => {
 
   const liveWebsites = await getLiveWebsites(organizationId!);
   const queue = new PQueue({ concurrency: 5 });
-  const results: (Domain | undefined)[] = await Promise.all(
+  await Promise.all(
     liveWebsites.map((site) => queue.add(() => wappalyze(site)))
   );
-  const domains = results.filter(filterEmpty);
 
-  await saveDomainsToDb(domains);
-  console.log(`Wappalyzer finished for ${domains.length} domains`);
+  console.log(`Wappalyzer finished for ${liveWebsites.length} domains`);
 };


### PR DESCRIPTION
This PR fixes several bugs with scans:

- Several scans, including portscanner, findomain, and amass, would fail if any individual component threw an error (e.g. a single IP for portscanner or single host for findomain). This adds error handling to prevent failing in that case.
- Wappalyzer would create a new domain without any organization, which would lead to results not displaying. This changes the logic to directly save the updated domain. We might want to consider adding a `{nullable: false}` constraint to the domain model to prevent having domains without an organization, though this would be a breaking change that would require deleting the domain table without having migrations (maybe a good time to make a bastion DB lambda function?)