### PR TITLE
Don't retry scan if recently failed

### DIFF
--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -126,7 +126,7 @@ const shouldRunScan = async ({
   const lastFinishedScanTask = await ScanTask.findOne(
     {
       scan: { id: scan.id },
-      status: 'finished',
+      status: In(['finished', 'failed']),
       ...orgFilter
     },
     {


### PR DESCRIPTION
Currently, the scheduler will continuously retry a failed scan, as it checks to see when a scan last succeeded in order to determine if it should be run. This PR changes this logic so that a scan will not be continuously retried when it fails, which prevents possibly high resource consumption and traffic generation from repeatedly failing scans.