### PR TITLE
Add require_version scan to cpe2cve

### DIFF
--- a/backend/src/tasks/cve.ts
+++ b/backend/src/tasks/cve.ts
@@ -63,7 +63,7 @@ export const handler = async (commandOptions: CommandOptions) => {
 
   // Should change this to spawnSync
   const res = execSync(
-    "cpe2cve -d ' ' -d2 , -o ' ' -o2 , -cpe 2 -e 2 -matches 3 -cve 2 -cvss 4 -cwe 5 nvd-dump/nvdcve-1.1-2*.json.gz",
+    "cpe2cve -d ' ' -d2 , -o ' ' -o2 , -cpe 2 -e 2 -matches 3 -cve 2 -cvss 4 -cwe 5 -require_version nvd-dump/nvdcve-1.1-2*.json.gz",
     { input: input, maxBuffer: buffer.constants.MAX_LENGTH }
   );
 


### PR DESCRIPTION
From documentation:

```
-require_version
    	ignore matches of CPEs with version ANY
```

This will reduce the number of false positive vulnerabilities detected by Crossfeed.