### PR TITLE
Don't wait for port 80

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -80,7 +80,7 @@ jobs:
           cp dev.env.example .env
           docker-compose up --build -d
           npm install -g wait-port
-          wait-port -t 3000 80 5432
+          wait-port -t 3000 5432
         working-directory: ./
       - name: Sync database
         run: docker-compose exec -T backend npx sls invoke local -f syncdb -d dangerouslyforce


### PR DESCRIPTION
Port 80 takes the longest to get ready because it serves the React code. We don't really need to do this, and this will make our tests a bit less flaky.
