### PR TITLE
Add tty: true to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - "80:3000"
     env_file:
       - ./.env
+    tty: true
 
   backend:
     build: ./backend


### PR DESCRIPTION
It looks like there's a known bug I've been running into with React in docker where it will periodically crash without this setting.

https://dev.to/igmrrf/docker-react-exited-with-code-0-398n