### PR TITLE
Add logs:GetLogEvents permission to serverless

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -31,6 +31,7 @@ provider:
       Action:
         - ecs:RunTask
         - iam:PassRole
+        - logs:GetLogEvents
       Resource: '*'
     - Effect: Allow
       Action:


### PR DESCRIPTION
This permission is needed to be able to access logs.