### PR TITLE
Set invitePending to true by default

### DIFF
--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -43,7 +43,7 @@ export class User extends BaseEntity {
   email: string;
 
   /** Whether the user's invite is pending */
-  @Column({ default: false })
+  @Column({ default: true })
   invitePending: boolean;
 
   /**


### PR DESCRIPTION
When a user signs up through login.gov and calls the auth callback URL, we currently set invitePending to false. It should be set to true.