### PR TITLE
Convert emails to lowercase

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -101,6 +101,8 @@ export const callback = async (event, context) => {
     };
   }
 
+  userInfo.email = userInfo.email.toLowerCase();
+
   // Look up user by email
   await connectToDatabase();
   let user = await User.findOne(

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -139,6 +139,8 @@ export const invite = wrapHandler(async (event) => {
 
   await connectToDatabase();
 
+  body.email = body.email.toLowerCase();
+
   // Check if user already exists
   let user = await User.findOne({
     email: body.email


### PR DESCRIPTION
This prevents invites from not working if the case of emails doesn't match by converting all email addresses to lower case first.