### PR TITLE
Fix terraform CI builds by changing AWS_PROFILE -> profile

### DIFF
--- a/infrastructure/prod.config
+++ b/infrastructure/prod.config
@@ -5,4 +5,4 @@
 key="PROD/frontend-prod.tfstate"
 bucket="cisa-cd-crossfeed-terraform-state-prod"
 region="us-east-1"
-AWS_PROFILE="default"
+profile="default"

--- a/infrastructure/stage.config
+++ b/infrastructure/stage.config
@@ -5,4 +5,4 @@
 key="STAGE/frontend-stage.tfstate"
 bucket="cisa-cd-crossfeed-terraform-state"
 region="us-east-1"
-AWS_PROFILE="default"
+profile="default"


### PR DESCRIPTION
AWS_PROFILE is not a valid configuration for the s3 backend, but [profile](https://www.terraform.io/docs/backends/types/s3.html#profile) is.