### PR TITLE
Include organization in censysipv4

### DIFF
--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -67,6 +67,7 @@ const downloadPath = async (
         domains.push(
           plainToClass(Domain, {
             name: matchingDomain.name,
+            organization: matchingDomain.organization,
             asn: item.autonomous_system?.asn,
             ip: item.ip,
             country: item.location?.country_code

--- a/backend/src/tasks/helpers/__mocks__/getAllDomains.ts
+++ b/backend/src/tasks/helpers/__mocks__/getAllDomains.ts
@@ -5,51 +5,63 @@ export default async () => {
   return [
     plainToClass(Domain, {
       name: 'first_file_testdomain1',
-      ip: '153.126.148.60'
+      ip: '153.126.148.60',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain2',
-      ip: '31.134.10.156'
+      ip: '31.134.10.156',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain3',
-      ip: '153.126.148.60'
+      ip: '153.126.148.60',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain4',
-      ip: '85.24.146.152'
+      ip: '85.24.146.152',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain5',
-      ip: '45.79.207.117'
+      ip: '45.79.207.117',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain6',
-      ip: '156.249.159.119'
+      ip: '156.249.159.119',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain7',
-      ip: '221.10.15.220'
+      ip: '221.10.15.220',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain8',
-      ip: '81.141.166.145'
+      ip: '81.141.166.145',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain9',
-      ip: '24.65.82.187'
+      ip: '24.65.82.187',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain10',
-      ip: '52.74.149.117'
+      ip: '52.74.149.117',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'first_file_testdomain11',
-      ip: '31.134.10.156'
+      ip: '31.134.10.156',
+      organization: '1234'
     }),
     plainToClass(Domain, {
       name: 'second_file_testdomain1',
-      ip: '1.1.1.1'
+      ip: '1.1.1.1',
+      organization: '1234'
     })
   ];
 };

--- a/backend/src/tasks/helpers/getAllDomains.ts
+++ b/backend/src/tasks/helpers/getAllDomains.ts
@@ -5,6 +5,6 @@ export default async (): Promise<Domain[]> => {
   await connectToDatabase();
 
   return Domain.find({
-    select: ['id', 'name', 'ip']
+    select: ['id', 'name', 'ip', 'organization']
   });
 };

--- a/backend/src/tasks/test/__snapshots__/censysIpv4.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/censysIpv4.test.ts.snap
@@ -7,6 +7,7 @@ Array [
     "country": "TR",
     "ip": "1.1.1.1",
     "name": "second_file_testdomain1",
+    "organization": "1234",
   },
 ]
 `;
@@ -18,66 +19,77 @@ Array [
     "country": "JP",
     "ip": "153.126.148.60",
     "name": "first_file_testdomain1",
+    "organization": "1234",
   },
   Domain {
     "asn": "16509",
     "country": "SG",
     "ip": "52.74.149.117",
     "name": "first_file_testdomain10",
+    "organization": "1234",
   },
   Domain {
     "asn": "48347",
     "country": "RU",
     "ip": "31.134.10.156",
     "name": "first_file_testdomain11",
+    "organization": "1234",
   },
   Domain {
     "asn": "48347",
     "country": "RU",
     "ip": "31.134.10.156",
     "name": "first_file_testdomain2",
+    "organization": "1234",
   },
   Domain {
     "asn": "7684",
     "country": "JP",
     "ip": "153.126.148.60",
     "name": "first_file_testdomain3",
+    "organization": "1234",
   },
   Domain {
     "asn": "8473",
     "country": "SE",
     "ip": "85.24.146.152",
     "name": "first_file_testdomain4",
+    "organization": "1234",
   },
   Domain {
     "asn": "63949",
     "country": "US",
     "ip": "45.79.207.117",
     "name": "first_file_testdomain5",
+    "organization": "1234",
   },
   Domain {
     "asn": "26484",
     "country": "US",
     "ip": "156.249.159.119",
     "name": "first_file_testdomain6",
+    "organization": "1234",
   },
   Domain {
     "asn": undefined,
     "country": undefined,
     "ip": "221.10.15.220",
     "name": "first_file_testdomain7",
+    "organization": "1234",
   },
   Domain {
     "asn": "2856",
     "country": "GB",
     "ip": "81.141.166.145",
     "name": "first_file_testdomain8",
+    "organization": "1234",
   },
   Domain {
     "asn": "6327",
     "country": "CA",
     "ip": "24.65.82.187",
     "name": "first_file_testdomain9",
+    "organization": "1234",
   },
 ]
 `;
@@ -96,6 +108,7 @@ Array [
     "domain": Domain {
       "ip": "1.1.1.1",
       "name": "second_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 53,
@@ -117,6 +130,7 @@ Array [
     "domain": Domain {
       "ip": "1.1.1.1",
       "name": "second_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 8080,
@@ -139,6 +153,7 @@ Array [
     "domain": Domain {
       "ip": "24.65.82.187",
       "name": "first_file_testdomain9",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 7547,
@@ -156,6 +171,7 @@ Array [
     "domain": Domain {
       "ip": "81.141.166.145",
       "name": "first_file_testdomain8",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 7547,
@@ -173,6 +189,7 @@ Array [
     "domain": Domain {
       "ip": "221.10.15.220",
       "name": "first_file_testdomain7",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 53,
@@ -232,6 +249,7 @@ Array [
     "domain": Domain {
       "ip": "52.74.149.117",
       "name": "first_file_testdomain10",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -261,6 +279,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -290,6 +309,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -321,6 +341,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "31.134.10.156",
       "name": "first_file_testdomain2",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -352,6 +373,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "31.134.10.156",
       "name": "first_file_testdomain11",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -442,6 +464,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "45.79.207.117",
       "name": "first_file_testdomain5",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -495,6 +518,7 @@ a img {
     "domain": Domain {
       "ip": "156.249.159.119",
       "name": "first_file_testdomain6",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 80,
@@ -1531,6 +1555,7 @@ a img {
     "domain": Domain {
       "ip": "52.74.149.117",
       "name": "first_file_testdomain10",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 443,
@@ -1560,6 +1585,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 443,
@@ -1589,6 +1615,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 443,
@@ -1617,6 +1644,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "156.249.159.119",
       "name": "first_file_testdomain6",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 443,
@@ -1637,6 +1665,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 143,
@@ -1657,6 +1686,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 143,
@@ -1674,6 +1704,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 993,
@@ -1691,6 +1722,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 993,
@@ -1708,6 +1740,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "52.74.149.117",
       "name": "first_file_testdomain10",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 27017,
@@ -1728,6 +1761,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 110,
@@ -1748,6 +1782,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 110,
@@ -1765,6 +1800,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 995,
@@ -1782,6 +1818,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 995,
@@ -1799,6 +1836,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 465,
@@ -1816,6 +1854,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 25,
@@ -1833,6 +1872,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain1",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 587,
@@ -1850,6 +1890,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 465,
@@ -1867,6 +1908,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 25,
@@ -1884,6 +1926,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "153.126.148.60",
       "name": "first_file_testdomain3",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 587,
@@ -1905,6 +1948,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "52.74.149.117",
       "name": "first_file_testdomain10",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 22,
@@ -1922,6 +1966,7 @@ on this server.</p>
     "domain": Domain {
       "ip": "85.24.146.152",
       "name": "first_file_testdomain4",
+      "organization": "1234",
     },
     "lastSeen": 2019-04-22T10:20:30.000Z,
     "port": 5900,


### PR DESCRIPTION
This fixes a bug with the CensysIPv4 scan where organizations wouldn't be included when updating a domain.