### PR TITLE
Better define behavior when switching between auth providers

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -114,16 +114,23 @@ export const callback = async (event, context) => {
     }
   );
 
+  const idKey = `${process.env.USE_COGNITO ? 'cognitoId' : 'loginGovId'}`;
+
   // If user does not exist, create it
   if (!user) {
     user = User.create({
       email: userInfo.email,
-      [`${process.env.USE_COGNITO ? 'cognitoId' : 'loginGovId'}`]: userInfo.sub,
+      [idKey]: userInfo.sub,
       firstName: '',
       lastName: '',
       userType: process.env.IS_OFFLINE ? 'globalAdmin' : 'standard',
       roles: []
     });
+    await user.save();
+  }
+
+  if (user[idKey] !== userInfo.sub) {
+    user[idKey] = userInfo.sub;
     await user.save();
   }
 

--- a/backend/test/auth.test.ts
+++ b/backend/test/auth.test.ts
@@ -4,11 +4,13 @@ import { User } from '../src/models';
 jest.mock('../src/api/login-gov');
 
 jest.mock('jsonwebtoken', () => ({
-  verify: (a, b, cb) =>
+  verify: (a, b, cb) => {
     cb(null, {
-      email: 'test2@crossfeed.cisa.gov',
-      email_verified: true
-    }),
+      email: a.split('TOKEN_')[1],
+      email_verified: true,
+      sub: Math.random() + ''
+    });
+  },
   sign: jest.requireActual('jsonwebtoken').sign
 }));
 
@@ -42,7 +44,7 @@ describe('auth', () => {
       const response = await request(app)
         .post('/auth/callback')
         .send({
-          token: 'TOKEN'
+          token: 'TOKEN_test2@crossfeed.cisa.gov'
         })
         .expect(200);
       expect(response.body.token).toBeTruthy();
@@ -51,6 +53,67 @@ describe('auth', () => {
       const user = await User.findOne(response.body.user.id);
       expect(user?.firstName).toEqual('');
       expect(user?.lastName).toEqual('');
+      process.env.USE_COGNITO = '';
+    });
+
+    it('success with cognito with two different ids - should overwrite cognitoId', async () => {
+      process.env.USE_COGNITO = '1';
+      let response = await request(app)
+        .post('/auth/callback')
+        .send({
+          token: 'TOKEN_test3@crossfeed.cisa.gov'
+        })
+        .expect(200);
+      expect(response.body.token).toBeTruthy();
+      expect(response.body.user).toBeTruthy();
+      expect(response.body.user.email).toEqual('test3@crossfeed.cisa.gov');
+      const { id, cognitoId } = response.body.user;
+      expect(cognitoId).toBeTruthy();
+      expect(id).toBeTruthy();
+
+      response = await request(app)
+        .post('/auth/callback')
+        .send({
+          token: 'TOKEN_test3@crossfeed.cisa.gov'
+        })
+        .expect(200);
+      const user = (await User.findOne(response.body.user.id)) as User;
+      expect(user.id).toEqual(id);
+      expect(user.cognitoId).not.toEqual(cognitoId);
+      process.env.USE_COGNITO = '';
+    });
+
+    it('login with login.gov and later cognito should preserve ids', async () => {
+      let response = await request(app)
+        .post('/auth/callback')
+        .send({
+          code: 'CODE',
+          state: 'STATE',
+          origState: 'ORIGSTATE',
+          nonce: 'NONCE'
+        })
+        .expect(200);
+      expect(response.body.token).toBeTruthy();
+      expect(response.body.user).toBeTruthy();
+      expect(response.body.user.email).toEqual('test@crossfeed.cisa.gov');
+      const { id, loginGovId } = response.body.user;
+      expect(id).toBeTruthy();
+      expect(loginGovId).toBeTruthy();
+
+      process.env.USE_COGNITO = '1';
+      response = await request(app)
+        .post('/auth/callback')
+        .send({
+          token: 'TOKEN_test@crossfeed.cisa.gov'
+        })
+        .expect(200);
+      expect(response.body.token).toBeTruthy();
+
+      const user = (await User.findOne(response.body.user.id)) as User;
+      expect(user.email).toEqual('test@crossfeed.cisa.gov');
+      expect(user.id).toEqual(id);
+      expect(user.loginGovId).toEqual(loginGovId);
+      expect(user.cognitoId).toBeTruthy();
       process.env.USE_COGNITO = '';
     });
   });


### PR DESCRIPTION
## 🗣 Description

- If a user switches auth providers (from cognito to login.gov, for example), the new auth provider's id will be stored on the User object, as well as the old. Previously, we were storing the auth provider's id only on creation.
- Additionally, if a user changes ids within an auth provider (for example, if their cognito user gets deleted and recreated), the new auth provider's id will be updated on the user model.