### PR TITLE
Fix log fetching from CloudWatch

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -5,6 +5,7 @@ process.env.DB_NAME = 'crossfeed_test';
 process.env.IS_LOCAL = 'true';
 process.env.CENSYS_API_ID = 'CENSYS_API_ID';
 process.env.CENSYS_API_SECRET = 'CENSYS_API_SECRET';
+process.env.FARGATE_LOG_GROUP_NAME = 'FARGATE_LOG_GROUP_NAME';
 process.env.FARGATE_MAX_CONCURRENCY = 100;
 process.env.USE_COGNITO = '';
 

--- a/backend/src/tasks/ecs-client.ts
+++ b/backend/src/tasks/ecs-client.ts
@@ -205,7 +205,8 @@ class ECSClient {
     } else {
       const response = await this.cloudWatchLogs!.getLogEvents({
         logGroupName: process.env.FARGATE_LOG_GROUP_NAME!,
-        logStreamName: `worker/main/${fargateTaskArn}`,
+        // Pick the ID from "arn:aws:ecs:us-east-1:957221700844:task/f59d71c6-3d23-4ee9-ad68-c7b810bf458b"
+        logStreamName: `worker/main/${fargateTaskArn.split('/')[1]}`,
         startFromHead: true
       }).promise();
       const res = response.$response.data;

--- a/backend/src/tasks/test/__snapshots__/ecs-client.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/ecs-client.test.ts.snap
@@ -12,6 +12,14 @@ exports[`getLogs local 1`] = `
 `;
 
 exports[`getLogs not local 1`] = `
+Object {
+  "logGroupName": "FARGATE_LOG_GROUP_NAME",
+  "logStreamName": "worker/main/f59d71c6-3d23-4ee9-ad68-c7b810bf458b",
+  "startFromHead": true,
+}
+`;
+
+exports[`getLogs not local 2`] = `
 "2020-08-26T13:06:26.714Z (ECS LOGS)commandOptions are {
 2020-08-26T13:06:26.714Z   organizationId: 'f0143eda-0e95-4748-ba49-a53069b1c738',
 2020-08-26T13:06:26.714Z   organizationName: 'CISA',

--- a/backend/src/tasks/test/ecs-client.test.ts
+++ b/backend/src/tasks/test/ecs-client.test.ts
@@ -57,174 +57,178 @@ jest.mock('aws-sdk', () => ({
   })),
   CloudWatchLogs: jest.fn().mockImplementation(() => ({
     getLogEvents: (e) => ({
-      promise: async () => ({
-        $response: {
-          data: {
-            events: [
-              {
-                timestamp: 1598447186714,
-                message: '(ECS LOGS)commandOptions are {',
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186714,
-                message:
-                  "  organizationId: 'f0143eda-0e95-4748-ba49-a53069b1c738',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186714,
-                message: "  organizationName: 'CISA',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186714,
-                message: "  scanId: 'e7ff7e7a-7391-431e-9b9e-437e823be3c9',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186714,
-                message: "  scanName: 'amass',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186714,
-                message: "  scanTaskId: 'fef01b7e-2da3-4508-b27a-3d8be8618488'",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186714,
-                message: '}',
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186715,
-                message: 'Running amass on organization CISA',
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447186917,
-                message: '=> DB Connected',
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: 'Running amass with args [',
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  'enum',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  '-ip',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  '-active',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  '-d',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  'cisa.gov',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  '-json',",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: "  '/out-0.6002422193137014.txt'",
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447187004,
-                message: ']',
-                ingestionTime: 1598447188176
-              },
-              {
-                timestamp: 1598447398914,
-                message: '=> DB Connected',
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: 'amass created/updated 2 new domains',
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: 'Running amass with args [',
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  'enum',",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  '-ip',",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  '-active',",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  '-d',",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  'cyber.dhs.gov',",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  '-json',",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: "  '/out-0.6002422193137014.txt'",
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447399308,
-                message: ']',
-                ingestionTime: 1598447403181
-              },
-              {
-                timestamp: 1598447675114,
-                message: '=> DB Connected',
-                ingestionTime: 1598447678181
-              },
-              {
-                timestamp: 1598447675463,
-                message: 'amass created/updated 23 new domains',
-                ingestionTime: 1598447678181
-              }
-            ],
-            nextForwardToken:
-              'f/35646574323683933005741047986357239768293194069041086465',
-            nextBackwardToken:
-              'b/35646563424217017969097517591536750076621854781830201344'
+      promise: async () => {
+        expect(e).toMatchSnapshot();
+        return {
+          $response: {
+            data: {
+              events: [
+                {
+                  timestamp: 1598447186714,
+                  message: '(ECS LOGS)commandOptions are {',
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186714,
+                  message:
+                    "  organizationId: 'f0143eda-0e95-4748-ba49-a53069b1c738',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186714,
+                  message: "  organizationName: 'CISA',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186714,
+                  message: "  scanId: 'e7ff7e7a-7391-431e-9b9e-437e823be3c9',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186714,
+                  message: "  scanName: 'amass',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186714,
+                  message:
+                    "  scanTaskId: 'fef01b7e-2da3-4508-b27a-3d8be8618488'",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186714,
+                  message: '}',
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186715,
+                  message: 'Running amass on organization CISA',
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447186917,
+                  message: '=> DB Connected',
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: 'Running amass with args [',
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  'enum',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  '-ip',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  '-active',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  '-d',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  'cisa.gov',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  '-json',",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: "  '/out-0.6002422193137014.txt'",
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447187004,
+                  message: ']',
+                  ingestionTime: 1598447188176
+                },
+                {
+                  timestamp: 1598447398914,
+                  message: '=> DB Connected',
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: 'amass created/updated 2 new domains',
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: 'Running amass with args [',
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  'enum',",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  '-ip',",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  '-active',",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  '-d',",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  'cyber.dhs.gov',",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  '-json',",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: "  '/out-0.6002422193137014.txt'",
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447399308,
+                  message: ']',
+                  ingestionTime: 1598447403181
+                },
+                {
+                  timestamp: 1598447675114,
+                  message: '=> DB Connected',
+                  ingestionTime: 1598447678181
+                },
+                {
+                  timestamp: 1598447675463,
+                  message: 'amass created/updated 23 new domains',
+                  ingestionTime: 1598447678181
+                }
+              ],
+              nextForwardToken:
+                'f/35646574323683933005741047986357239768293194069041086465',
+              nextBackwardToken:
+                'b/35646563424217017969097517591536750076621854781830201344'
+            }
           }
-        }
-      })
+        };
+      }
     })
   }))
 }));
@@ -249,7 +253,9 @@ describe('getLogs', () => {
   });
   test('not local', async () => {
     const client = new ECSClient(false);
-    const logs = await client.getLogs('testArn');
+    const logs = await client.getLogs(
+      'arn:aws:ecs:us-east-1:957221700844:task/f59d71c6-3d23-4ee9-ad68-c7b810bf458b'
+    );
     expect(logs).toMatchSnapshot();
     expect(logs).toContain('ECS LOGS');
   });


### PR DESCRIPTION
Fixes #374 by passing in the right logStreamName parameter to the AWS CloudWatch API.