### PR TITLE
Create lgtm.yml

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,2 @@
+queries:
+  - exclude: js/unused-local-variable


### PR DESCRIPTION
Excluding `js/unused-local-variable` alerts because they aren't that useful (and if we really want them, we should add them as a lint rule to be run on CI).