### PR TITLE
Remove WORKER_USER_AGENT and WORKER_SIGNATURE_PRIVATE_KEY from env variables

### DIFF
--- a/backend/env.yml
+++ b/backend/env.yml
@@ -24,9 +24,7 @@ staging:
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'
   USE_COGNITO: 1
   REACT_APP_USER_POOL_ID: us-east-1_uxiY8DOum
-  WORKER_USER_AGENT: 'Mozilla/5.0 (compatible; Crossfeed_Staging/1.0; +https://cisagov.github.io/crossfeed/scans)'
   WORKER_SIGNATURE_PUBLIC_KEY: ${ssm:/crossfeed/staging/WORKER_SIGNATURE_PUBLIC_KEY}
-  WORKER_SIGNATURE_PRIVATE_KEY: ${ssm:/crossfeed/staging/WORKER_SIGNATURE_PRIVATE_KEY}
 
 prod:
   DB_DIALECT: 'postgres'
@@ -54,9 +52,7 @@ prod:
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'
   USE_COGNITO: 1
   REACT_APP_USER_POOL_ID: test
-  WORKER_USER_AGENT: 'Mozilla/5.0 (compatible; Crossfeed/1.0; +https://cisagov.github.io/crossfeed/scans)'
   WORKER_SIGNATURE_PUBLIC_KEY: ${ssm:/crossfeed/prod/WORKER_SIGNATURE_PUBLIC_KEY}
-  WORKER_SIGNATURE_PRIVATE_KEY: ${ssm:/crossfeed/prod/WORKER_SIGNATURE_PRIVATE_KEY}
 
 staging-vpc:
   securityGroupIds:


### PR DESCRIPTION
Addresses failing deploys, noted in #389. We don't need either of these env variables, because the worker grabs these variables directly from SSM (see the terraform definition).

I'd imagine that WORKER_SIGNATURE_PRIVATE_KEY is the largest env variable we have.