### PR TITLE
Re-add WORKER_USER_AGENT

### DIFF
--- a/backend/env.yml
+++ b/backend/env.yml
@@ -24,6 +24,7 @@ staging:
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'
   USE_COGNITO: 1
   REACT_APP_USER_POOL_ID: us-east-1_uxiY8DOum
+  WORKER_USER_AGENT: 'Mozilla/5.0 (compatible; Crossfeed_Staging/1.0; +https://cisagov.github.io/crossfeed/scans)'
   WORKER_SIGNATURE_PUBLIC_KEY: ${ssm:/crossfeed/staging/WORKER_SIGNATURE_PUBLIC_KEY}
 
 prod:
@@ -52,6 +53,7 @@ prod:
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'
   USE_COGNITO: 1
   REACT_APP_USER_POOL_ID: test
+  WORKER_USER_AGENT: 'Mozilla/5.0 (compatible; Crossfeed/1.0; +https://cisagov.github.io/crossfeed/scans)'
   WORKER_SIGNATURE_PUBLIC_KEY: ${ssm:/crossfeed/prod/WORKER_SIGNATURE_PUBLIC_KEY}
 
 staging-vpc:


### PR DESCRIPTION
This variable actually doesn't come from SSM, so it's needed for our user agent string to be sent from the worker. We could later retrieve it from SSM, though.