### PR TITLE
Change "Never" to "None" for less confusion on date formatting

### DIFF
--- a/frontend/src/pages/Scans/ScanTasksView.tsx
+++ b/frontend/src/pages/Scans/ScanTasksView.tsx
@@ -21,7 +21,7 @@ interface Errors {
 
 const dateAccessor = (date?: string) => {
   return !date || new Date(date).getTime() === new Date(0).getTime()
-    ? 'Never'
+    ? 'None'
     : `${formatDistanceToNow(parseISO(date))} ago`;
 };
 


### PR DESCRIPTION
As per what we discussed in the UX meeting -- saying that a scantask's end time is "Never" could give the impression that the scantask will never end.