### PR TITLE
Fix prod deploy

### DIFF
--- a/backend/env.yml
+++ b/backend/env.yml
@@ -48,7 +48,7 @@ prod:
   FRONTEND_DOMAIN: 'https://crossfeed.cyber.dhs.gov'
   SLS_LAMBDA_PREFIX: '${self:service.name}-${self:provider.stage}'
   USE_COGNITO: 1
-  REACT_APP_USER_POOL_ID: test
+  REACT_APP_USER_POOL_ID: us-east-1_MZgKoBmkN
   WORKER_USER_AGENT: 'Mozilla/5.0 (compatible; Crossfeed/1.0; +https://cisagov.github.io/crossfeed/scans)'
   WORKER_SIGNATURE_PUBLIC_KEY: ${ssm:/crossfeed/prod/WORKER_SIGNATURE_PUBLIC_KEY}
 


### PR DESCRIPTION
Sets the REACT_APP_USER_POOL_ID for the backend to fix the prod deploy. I've gone ahead and deployed this to prod already, so it's working.

Fixes #401.