### PR TITLE
Ignore wrong Tomcat version, add filtering / tests for setProducts

### DIFF
--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -151,7 +151,7 @@ export class Service extends BaseEntity {
       }
     }
 
-    if (this.censysMetadata) {
+    if (this.censysMetadata && Object.values(this.censysMetadata).length > 0) {
       let cpe;
 
       if (this.censysMetadata.manufacturer && this.censysMetadata.product) {

--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -12,6 +12,15 @@ import {
 import { Domain } from './domain';
 import { Scan } from './scan';
 
+const filterProducts = (product: Product) => {
+  // Filter out false positives.
+  const { cpe, version } = product;
+  if (cpe === 'cpe:/a:apache:tomcat' && version === '1.1') {
+    return false;
+  }
+  return true;
+};
+
 interface Product {
   // Common name
   name: string;
@@ -164,6 +173,6 @@ export class Service extends BaseEntity {
       else misc.push(product);
     }
 
-    this.products = Object.values(products).concat(misc);
+    this.products = Object.values(products).concat(misc).filter(filterProducts);
   }
 }

--- a/backend/src/models/test/__snapshots__/service.test.ts.snap
+++ b/backend/src/models/test/__snapshots__/service.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`service set products 1`] = `
+Array [
+  Object {
+    "cpe": "cpe1",
+    "icon": "icon",
+    "name": "name",
+    "tags": Array [],
+    "version": "version",
+  },
+  Object {
+    "cpe": undefined,
+    "description": undefined,
+    "name": undefined,
+    "product": undefined,
+    "revision": undefined,
+    "tags": Array [],
+    "version": undefined,
+  },
+]
+`;

--- a/backend/src/models/test/__snapshots__/service.test.ts.snap
+++ b/backend/src/models/test/__snapshots__/service.test.ts.snap
@@ -9,14 +9,5 @@ Array [
     "tags": Array [],
     "version": "version",
   },
-  Object {
-    "cpe": undefined,
-    "description": undefined,
-    "name": undefined,
-    "product": undefined,
-    "revision": undefined,
-    "tags": Array [],
-    "version": undefined,
-  },
 ]
 `;

--- a/backend/src/models/test/service.test.ts
+++ b/backend/src/models/test/service.test.ts
@@ -1,0 +1,46 @@
+import { connectToDatabase } from '../connection';
+import { Service } from '../service';
+
+describe('service', () => {
+  beforeAll(async () => {
+    await connectToDatabase();
+  });
+  test('set products', async () => {
+    const service = await Service.create({
+      port: 443
+    }).save();
+    service.wappalyzerResults = [
+      {
+        cpe: 'cpe1',
+        name: 'name',
+        version: 'version',
+        slug: 'slug',
+        icon: 'icon',
+        website: 'website',
+        confidence: 0,
+        categories: []
+      }
+    ];
+    await service.save();
+    expect(service.products).toMatchSnapshot();
+  });
+  test('set products should not include a blacklisted product', async () => {
+    const service = await Service.create({
+      port: 443
+    }).save();
+    service.wappalyzerResults = [
+      {
+        cpe: 'cpe:/a:apache:tomcat',
+        name: 'name',
+        version: '1.1',
+        slug: 'slug',
+        icon: 'icon',
+        website: 'website',
+        confidence: 0,
+        categories: []
+      }
+    ];
+    await service.save();
+    expect(service.products.length).toEqual(1);
+  });
+});

--- a/backend/src/models/test/service.test.ts
+++ b/backend/src/models/test/service.test.ts
@@ -41,6 +41,6 @@ describe('service', () => {
       }
     ];
     await service.save();
-    expect(service.products.length).toEqual(1);
+    expect(service.products.length).toEqual(0);
   });
 });


### PR DESCRIPTION
- Ignore Tomcat 1.1 version in the `products` array. This is a false positive reported by wappalyzer (https://github.com/AliasIO/wappalyzer/issues/3305).

- Fixed an issue where if censysMetadata is an empty object, an empty product with this value would be added to `products`:

```
  Object {
    "cpe": undefined,
    "description": undefined,
    "name": undefined,
    "product": undefined,
    "revision": undefined,
    "tags": Array [],
    "version": undefined,
  }
```