### PR TITLE
Fix GitHub Pages deployment to custom domain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,7 @@ jobs:
         working-directory: ./docs
         env:
           JEKYLL_ENV: producation
+      - run: echo "docs.crossfeed.cyber.dhs.gov" >> docs/_site/CNAME
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: crazy-max/ghaction-github-pages@v2.1.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - run: gem install bundler:2.1.4
       - run: bundle install --jobs 4 --retry 3
         working-directory: ./docs
-      - run: bundle exec jekyll build --baseurl /crossfeed
+      - run: bundle exec jekyll build
         working-directory: ./docs
         env:
           JEKYLL_ENV: production

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       - run: bundle exec jekyll build --baseurl /crossfeed
         working-directory: ./docs
         env:
-          JEKYLL_ENV: producation
+          JEKYLL_ENV: production
       - run: echo "docs.crossfeed.cyber.dhs.gov" >> docs/_site/CNAME
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
I already added the CNAME manually by going into Settings and setting the custom domain, but this PR ensures that this file is added on every GitHub Pages build.

Also, fix a typo with JEKYLL_ENV.

Finally, removes the baseurl option so that the docs site can be published at https://docs.crossfeed.cyber.dhs.gov/.