### PR TITLE
Remove callback_urls from cognito user pool

### DIFF
--- a/infrastructure/users.tf
+++ b/infrastructure/users.tf
@@ -35,7 +35,6 @@ resource "aws_cognito_user_pool_domain" "auth_domain" {
 resource "aws_cognito_user_pool_client" "client" {
   name         = "crossfeed"
   user_pool_id = aws_cognito_user_pool.pool.id
-  callback_urls = ["http://localhost"]
   supported_identity_providers = ["COGNITO"]
   allowed_oauth_scopes = ["email", "openid"]
   allowed_oauth_flows = ["code"]


### PR DESCRIPTION
I don't think this parameter has any effect, especially given that `localhost` isn't used on prod.