### PR TITLE
Update FAQ with link to crossfeed public announcement

### DIFF
--- a/docs/scans.md
+++ b/docs/scans.md
@@ -20,4 +20,4 @@ All requests are also signed in order to allow verification that the request was
 
 ### Who can I contact with further questions?
 
-Please contact <a href="mailto:support@crossfeed.cyber.dhs.gov">support@crossfeed.cyber.dhs.gov</a>.
+Please go to [https://www.cisa.gov/crossfeed](https://www.cisa.gov/crossfeed) for more information on CISA's use of Crossfeed and additional contact details.


### PR DESCRIPTION
This way, we also keep `support@crossfeed.cyber.dhs.gov` solely for technical issues / request verification and direct people to the CISA website announcement for any further questions.