### PR TITLE
Add API Gateway logs

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -18,6 +18,8 @@ provider:
   stage: ${opt:stage, 'dev'}
   environment: ${file(env.yml):${self:provider.stage}}
   vpc: ${file(env.yml):${self:provider.stage}-vpc, ''}
+  logs:
+    restApi: true
   deploymentBucket:
     serverSideEncryption: AES256
   iamRoleStatements:


### PR DESCRIPTION
Add API Gateway logs so we can log which endpoints on the API are called. Requests are logged to CloudWatch.