### PR TITLE
Revert "Remove callback_urls from cognito user pool"

### DIFF
--- a/infrastructure/users.tf
+++ b/infrastructure/users.tf
@@ -35,6 +35,7 @@ resource "aws_cognito_user_pool_domain" "auth_domain" {
 resource "aws_cognito_user_pool_client" "client" {
   name         = "crossfeed"
   user_pool_id = aws_cognito_user_pool.pool.id
+  callback_urls = ["http://localhost"]
   supported_identity_providers = ["COGNITO"]
   allowed_oauth_scopes = ["email", "openid"]
   allowed_oauth_flows = ["code"]


### PR DESCRIPTION
Reverts cisagov/crossfeed#431

We apparently need this, or we get the error

```
Error updating Cognito User Pool Client: InvalidOAuthFlowException: CallbackUrls can not be empty when code flow or implicit flow is selected
```


https://github.com/cisagov/crossfeed/runs/1103766857