### PR TITLE
Don't delete rows when certain associated rows are deleted

### DIFF
--- a/backend/src/models/domain.ts
+++ b/backend/src/models/domain.ts
@@ -39,7 +39,7 @@ export class Domain extends BaseEntity {
   fromRootDomain: string;
 
   @ManyToOne((type) => Scan, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
     onUpdate: 'CASCADE'
   })
   discoveredBy: Scan;

--- a/backend/src/models/organization.ts
+++ b/backend/src/models/organization.ts
@@ -65,7 +65,7 @@ export class Organization extends BaseEntity {
   granularScans: Scan[];
 
   @ManyToOne((type) => User, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
     onUpdate: 'CASCADE'
   })
   createdBy: User;

--- a/backend/src/models/scan.ts
+++ b/backend/src/models/scan.ts
@@ -72,7 +72,7 @@ export class Scan extends BaseEntity {
   organizations: Organization[];
 
   @ManyToOne((type) => User, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
     onUpdate: 'CASCADE'
   })
   createdBy: User;

--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -58,7 +58,7 @@ export class Service extends BaseEntity {
   domain: Domain;
 
   @ManyToOne((type) => Scan, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
     onUpdate: 'CASCADE'
   })
   discoveredBy: Scan;


### PR DESCRIPTION
Currently, when a scan is deleted, this will cause any discovered domains to be deleted due to an associated ManyToOne cascade relationship. This PR fixes this so that rows aren't deleted when certain associated rows are deleted.