### PR TITLE
Use res.json on error

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -38,7 +38,8 @@ const handlerToExpress = (handler) => async (req, res, next) => {
     res.status(statusCode).json(parsedBody);
   } catch (e) {
     // Not a JSON body
-    res.status(statusCode).json({ resp: body });
+    res.setHeader('content-type', 'text/plain');
+    res.status(statusCode).send(body);
   }
 };
 

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -38,7 +38,7 @@ const handlerToExpress = (handler) => async (req, res, next) => {
     res.status(statusCode).json(parsedBody);
   } catch (e) {
     // Not a JSON body
-    res.status(statusCode).send(body);
+    res.status(statusCode).json({ resp: body });
   }
 };
 

--- a/backend/test/scan-tasks.test.ts
+++ b/backend/test/scan-tasks.test.ts
@@ -213,7 +213,8 @@ describe('domains', () => {
             userType: 'globalView'
           })
         )
-        .expect(200);
+        .expect(200)
+        .expect('Content-Type', /text\/plain/); // Prevent XSS by setting text/plain header
       expect(response.text).toEqual('logs');
       expect(getLogs).toHaveBeenCalledWith('fargateTaskArn');
     });


### PR DESCRIPTION
Rather than using res.send on errors, which can be vulnerable to XSS attacks if user data is included, this changes handlerToExpress to use res.json on a parsing error.