### PR TITLE
Exclude F5 from Intrigue Ident, fix cpe format

### DIFF
--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -32,6 +32,7 @@ const filterProducts = (product: Product) => {
   if (
     cpe === 'cpe:/a:f5:big-ip_application_security_manager:14.0.0_and_later:'
   ) {
+    // Intrigue Ident returns an invalid CPE version. TODO: ignore all invalid versions in CPEs.
     return false;
   }
   return true;

--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -20,13 +20,18 @@ const filterProducts = (product: Product) => {
     // https://github.com/AliasIO/wappalyzer/issues/3305
     return false;
   }
-  if (cpe === 'cpe:2.3:a:apache:coyote:1.1:') {
+  if (cpe === 'cpe:/a:apache:coyote:1.1:') {
     // Intrigue Ident incorrectly detects "Apache Coyote 1.1"
     // https://github.com/intrigueio/intrigue-ident/issues/51
     return false;
   }
-  if (cpe === 'cpe:2.3::generic:unauthorized::') {
+  if (cpe === 'cpe:/a::generic:unauthorized::') {
     // Intrigue Ident sometimes detects "Unauthorized" CPEs
+    return false;
+  }
+  if (
+    cpe === 'cpe:/a:f5:big-ip_application_security_manager:14.0.0_and_later:'
+  ) {
     return false;
   }
   return true;


### PR DESCRIPTION
Excludes F5 from Intrigue Ident, which leads to some false positives. We should eventually move this into the application process so we don't need to commit each time we flag a false positive.