### PR TITLE
Ignore typescript for frontend dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "typescript"
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:


### PR DESCRIPTION
As a followup to #547 -- we need to ignore typescript so that this change doesn't get automerged again.