### PR TITLE
Move elasticsearch service-linked role out of Terraform

### DIFF
--- a/docs/contributing/deployment.md
+++ b/docs/contributing/deployment.md
@@ -97,6 +97,12 @@ First, make sure you set the following SSM variables manually through the AWS Co
 - `/crossfeed/staging/WORKER_SIGNATURE_PRIVATE_KEY`
 - `/crossfeed/staging/REACT_APP_TERMS_VERSION`
 
+You must also [create a service-linked role for Amazon ES](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/slr-es.html#create-slr) (this only needs to be created once per AWS account):
+
+```bash
+aws iam create-service-linked-role --aws-service-name es.amazonaws.com
+```
+
 Then, run `cp stage.config .env` and change the variables in `.env` to use a bucket you have access to to store state.
 
 Make sure you configure the default AWS profile using `aws configure` , or set the `AWS_PROFILE` environment variable in `.env`.

--- a/infrastructure/es.tf
+++ b/infrastructure/es.tf
@@ -71,13 +71,6 @@ POLICY
   tags = {
     Project = var.project
   }
-
-  depends_on = [aws_iam_service_linked_role.es]
-}
-
-resource "aws_iam_service_linked_role" "es" {
-  aws_service_name = "es.amazonaws.com"
-  custom_suffix = "crossfeed-${var.stage}"
 }
 
 resource "aws_cloudwatch_log_resource_policy" "es" {

--- a/infrastructure/es.tf
+++ b/infrastructure/es.tf
@@ -77,6 +77,7 @@ POLICY
 
 resource "aws_iam_service_linked_role" "es" {
   aws_service_name = "es.amazonaws.com"
+  custom_suffix = "crossfeed-${var.stage}"
 }
 
 resource "aws_cloudwatch_log_resource_policy" "es" {


### PR DESCRIPTION
This will fix the prod deployment issues. Essentially, we need one elasticsearch service-linked role for AWS elasticsearch to function from within a VPC, but we can't have more than one. From https://github.com/terraform-providers/terraform-provider-aws/issues/5218, it appears that the best way to do this is just to perform a one-time creation of the role outside Terraform.