### PR TITLE
Scheduler - handle failed tasks without a finishedAt column

### DIFF
--- a/backend/src/api/scan-tasks.ts
+++ b/backend/src/api/scan-tasks.ts
@@ -126,6 +126,7 @@ export const kill = wrapHandler(async (event) => {
   }
   if (scanTask) {
     scanTask.status = 'failed';
+    scanTask.finishedAt = new Date();
     scanTask.output = 'Manually stopped at ' + new Date().toISOString();
     await ScanTask.save(scanTask);
   }

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -2,7 +2,7 @@ import { Handler } from 'aws-lambda';
 import { connectToDatabase, Scan, Organization, ScanTask } from '../models';
 import ECSClient from './ecs-client';
 import { SCAN_SCHEMA } from '../api/scans';
-import { In } from 'typeorm';
+import { In, IsNull, Not } from 'typeorm';
 
 class Scheduler {
   ecs: ECSClient;
@@ -231,6 +231,7 @@ const shouldRunScan = async ({
     {
       scan: { id: scan.id },
       status: In(['finished', 'failed']),
+      finishedAt: Not(IsNull()),
       ...orgFilter
     },
     {

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -120,6 +120,7 @@ class Scheduler {
       console.error(error);
       scanTask.output = JSON.stringify(error);
       scanTask.status = 'failed';
+      scanTask.finishedAt = new Date();
     }
     await scanTask.save();
   };


### PR DESCRIPTION
- When a failed scan occurred without a finishedAt column, this would cause the scheduler to immediately schedule a new scan, when. Changes the scheduler logic to ignore such scantasks to prevent this bug.

- Make sure that finishedAt is always set whenever a scan is 1) manually killed or 2) fails due to an ECS error with RunTask (these were the two cases in which the bug above would occur).