### PR TITLE
More efficient search-sync for domains

### DIFF
--- a/backend/src/tasks/test/search-sync.test.ts
+++ b/backend/src/tasks/test/search-sync.test.ts
@@ -64,14 +64,14 @@ describe('search_sync', () => {
     const domain = await Domain.create({
       name: 'cisa.gov',
       organization,
-      syncedAt: new Date('2020-10-10')
+      syncedAt: new Date('9999-10-10')
     }).save();
 
     await Service.create({
       service: 'https',
       port: 443,
       domain,
-      updatedAt: new Date('2020-10-11')
+      updatedAt: new Date('9999-10-11')
     }).save();
 
     await searchSync({
@@ -85,17 +85,42 @@ describe('search_sync', () => {
     expect(updateDomains).toBeCalled();
   });
 
+  test('should not update a domain if a service has not changed', async () => {
+    const domain = await Domain.create({
+      name: 'cisa.gov',
+      organization,
+      syncedAt: new Date('9999-10-10')
+    }).save();
+
+    await Service.create({
+      service: 'https',
+      port: 443,
+      domain,
+      updatedAt: new Date('9999-9-11')
+    }).save();
+
+    await searchSync({
+      organizationId: organization.id,
+      organizationName: 'organizationName',
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    expect(updateDomains).not.toBeCalled();
+  });
+
   test('should update a domain if a vulnerability has changed', async () => {
     const domain = await Domain.create({
       name: 'cisa.gov',
       organization,
-      syncedAt: new Date('2020-10-10')
+      syncedAt: new Date('9999-10-10')
     }).save();
 
     await Vulnerability.create({
       domain,
       title: 'vuln',
-      updatedAt: new Date('2020-10-11')
+      updatedAt: new Date('9999-10-11')
     }).save();
 
     await searchSync({
@@ -107,6 +132,82 @@ describe('search_sync', () => {
     });
 
     expect(updateDomains).toBeCalled();
+  });
+
+  test('should not update a domain if a vulnerability has not changed', async () => {
+    const domain = await Domain.create({
+      name: 'cisa.gov',
+      organization,
+      syncedAt: new Date('9999-10-10')
+    }).save();
+
+    await Vulnerability.create({
+      domain,
+      title: 'vuln',
+      updatedAt: new Date('9999-9-11')
+    }).save();
+
+    await searchSync({
+      organizationId: organization.id,
+      organizationName: 'organizationName',
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    expect(updateDomains).not.toBeCalled();
+  });
+
+  test('should update a domain if an organization has changed', async () => {
+    organization = await Organization.create({
+      name: 'test-' + Math.random(),
+      rootDomains: ['test-' + Math.random()],
+      ipBlocks: [],
+      isPassive: false,
+      updatedAt: new Date('9999-10-11')
+    }).save();
+
+    const domain = await Domain.create({
+      name: 'cisa.gov',
+      organization,
+      syncedAt: new Date('9999-10-10')
+    }).save();
+
+    await searchSync({
+      organizationId: organization.id,
+      organizationName: 'organizationName',
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    expect(updateDomains).toBeCalled();
+  });
+
+  test('should not update a domain if an organization has not changed', async () => {
+    organization = await Organization.create({
+      name: 'test-' + Math.random(),
+      rootDomains: ['test-' + Math.random()],
+      ipBlocks: [],
+      isPassive: false,
+      updatedAt: new Date('9999-9-11')
+    }).save();
+
+    const domain = await Domain.create({
+      name: 'cisa.gov',
+      organization,
+      syncedAt: new Date('9999-10-10')
+    }).save();
+
+    await searchSync({
+      organizationId: organization.id,
+      organizationName: 'organizationName',
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    expect(updateDomains).not.toBeCalled();
   });
 
 
@@ -114,15 +215,15 @@ describe('search_sync', () => {
     const domain = await Domain.create({
       name: 'cisa.gov',
       organization,
-      syncedAt: new Date('2020-09-19T19:57:32.346Z'),
-      updatedAt: new Date('2020-09-20T19:57:32.346Z')
+      syncedAt: new Date('9999-09-19T19:57:32.346Z'),
+      updatedAt: new Date('9999-09-20T19:57:32.346Z')
     }).save();
 
     const service = await Service.create({
       service: 'https',
       port: 443,
       domain,
-      updatedAt: new Date('2020-09-12T19:57:32.346Z')
+      updatedAt: new Date('9999-09-12T19:57:32.346Z')
     }).save();
 
     const vulnerability = await Vulnerability.create({

--- a/backend/src/tasks/test/search-sync.test.ts
+++ b/backend/src/tasks/test/search-sync.test.ts
@@ -210,7 +210,6 @@ describe('search_sync', () => {
     expect(updateDomains).not.toBeCalled();
   });
 
-
   test('should update a domain if a domain has changed', async () => {
     const domain = await Domain.create({
       name: 'cisa.gov',

--- a/backend/src/tasks/test/search-sync.test.ts
+++ b/backend/src/tasks/test/search-sync.test.ts
@@ -85,6 +85,31 @@ describe('search_sync', () => {
     expect(updateDomains).toBeCalled();
   });
 
+  test('should update a domain if a vulnerability has changed', async () => {
+    const domain = await Domain.create({
+      name: 'cisa.gov',
+      organization,
+      syncedAt: new Date('2020-10-10')
+    }).save();
+
+    await Vulnerability.create({
+      domain,
+      title: 'vuln',
+      updatedAt: new Date('2020-10-11')
+    }).save();
+
+    await searchSync({
+      organizationId: organization.id,
+      organizationName: 'organizationName',
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    expect(updateDomains).toBeCalled();
+  });
+
+
   test('should update a domain if a domain has changed', async () => {
     const domain = await Domain.create({
       name: 'cisa.gov',


### PR DESCRIPTION
Fixes the OOM errors we've been seeing with search-sync on production.

- search-sync only syncs a maximum of 500 domains at a time
- search-sync gets only the domainIds that need syncing, rather than having to loop through all domains each time
- Add more exhaustive tests