### PR TITLE
Fix censys scan issue by never passing an empty array of organizations

### DIFF
--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -143,7 +143,9 @@ export const handler = async (commandOptions: CommandOptions) => {
     { relations: ['organizations'] }
   );
 
-  const orgs = scan?.organizations && scan?.organizations.map((org) => org.id);
+  const orgs = scan?.organizations?.length
+    ? undefined
+    : scan?.organizations.map((org) => org.id);
 
   const allDomains = await getAllDomains(orgs);
 


### PR DESCRIPTION
Fixes #622 -- this issue was likely caused because when censys is called in a non-granular fashion, an empty array is passed to `organizations` instead of `undefined`. This ends up adding `()` in the query builder, causing a syntax error.