### PR TITLE
Link vulnerability names to NVD

### DIFF
--- a/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
+++ b/frontend/src/pages/Vulnerabilities/Vulnerabilities.tsx
@@ -44,18 +44,9 @@ export const renderExpandedVulnerability = (row: Row<Vulnerability>) => {
   const { original } = row;
   return (
     <div className={classes.expandedRoot}>
-      <h4>Details</h4>
+      <h3>Details</h3>
       <div className={classes.desc}>
-        {original.cve && (
-          <a
-            href={`https://nvd.nist.gov/vuln/detail/${original.cve}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            View vulnerability description
-          </a>
-        )}
-        <h3>Vulnerability history</h3>
+        <h4>Vulnerability history</h4>
         {original.actions.map((action, num) => {
           const val = action.automatic ? (
             <>Vulnerability automatically marked as remediated</>
@@ -90,6 +81,15 @@ export const Vulnerabilities: React.FC = () => {
     {
       Header: 'Title',
       accessor: 'title',
+      Cell: ({value, row}: CellProps<Vulnerability>) => (
+        <a
+        href={`https://nvd.nist.gov/vuln/detail/${row.original.cve}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        >
+          {value}
+        </a>
+      ),
       width: 800,
       Filter: ColumnFilter
     },


### PR DESCRIPTION
Link vulnerability names to the NVD site, so the user doesn't have to expand each vulnerability to get the URL for the CVE.

Screenshot (test data):

![image](https://user-images.githubusercontent.com/1689183/94841018-63b3f980-03e7-11eb-9991-5392034f77a6.png)
