### PR TITLE
Reduce censys concurrency, add CPU / memory

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -79,8 +79,8 @@ export const SCAN_SCHEMA: ScanSchema = {
     type: 'fargate',
     isPassive: true,
     global: true,
-    cpu: '1024',
-    memory: '4096',
+    cpu: '2048',
+    memory: '6144',
     numChunks: 20,
     description: 'Fetch passive port and banner data from censys ipv4 dataset'
   },

--- a/backend/src/tasks/censysIpv4.ts
+++ b/backend/src/tasks/censysIpv4.ts
@@ -149,7 +149,7 @@ export const handler = async (commandOptions: CommandOptions) => {
 
   const allDomains = await getAllDomains(orgs);
 
-  const queue = new PQueue({ concurrency: 5 });
+  const queue = new PQueue({ concurrency: 2 });
 
   const numFiles = Object.keys(files).length;
   const fileNames = Object.keys(files).sort();


### PR DESCRIPTION
Trying to fix #624. It appears that censys usually runs well, except for that it fails at the end, so maybe we're just running out of memory?