### PR TITLE
Terraform - Remove "stage" tags from ssm parameters, for consistency

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -10,7 +10,6 @@ resource "aws_ssm_parameter" "prod_api_domain" {
 
   tags = {
     Project = var.project
-    Stage   = var.stage
   }
 }
 
@@ -22,6 +21,5 @@ resource "aws_ssm_parameter" "stage_api_domain" {
 
   tags = {
     Project = var.project
-    Stage   = var.stage
   }
 }

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -258,7 +258,6 @@ resource "aws_ssm_parameter" "webscraper_s3_bucket_name" {
 
   tags = {
     Project = var.project
-    Stage   = var.stage
   }
 }
 


### PR DESCRIPTION
For consistency with all other SSM variables. Also, we would end up accidentally constantly changing the tag for "stage_api_domain" from staging -> prod -> staging etc. because of how the tags were set up.