### PR TITLE
searchSync - better error handling when s3 files don't exist

### DIFF
--- a/backend/src/tasks/s3-client.ts
+++ b/backend/src/tasks/s3-client.ts
@@ -28,12 +28,21 @@ class S3Client {
    * @param s3Key s3Key attribute of the webpage.
    */
   async getWebpageBody(s3Key: string) {
-    const params = {
-      Bucket: process.env.WEBSCRAPER_S3_BUCKET_NAME!,
-      Key: `${s3Key}/latest/body.txt`
-    };
-    const data = await this.s3.getObject(params).promise();
-    return data.Body?.toString('utf-8');
+    try {
+      const params = {
+        Bucket: process.env.WEBSCRAPER_S3_BUCKET_NAME!,
+        Key: `${s3Key}/latest/body.txt`
+      };
+      const data = await this.s3.getObject(params).promise();
+      return data.Body?.toString('utf-8');
+    } catch (e) {
+      if (e?.code === 'NoSuchKey') {
+        console.warn('Files for key ' + s3Key + ' not found');
+        return '';
+      }
+      console.error(e);
+      throw e;
+    }
   }
 }
 

--- a/backend/src/tasks/search-sync.ts
+++ b/backend/src/tasks/search-sync.ts
@@ -71,7 +71,7 @@ export const handler = async (commandOptions: CommandOptions) => {
   // The response actually has keys "webpage_id", "webpage_createdAt", etc.
   const s3Client = new S3Client();
   const queue = new PQueue({ concurrency: 10 });
-  const webpages: WebpageRecord[] = await qs_.take(MAX_RESULTS).execute();
+  const webpages: WebpageRecord[] = await qs_.take(100).execute();
   console.log(
     `Got ${webpages.length} webpages. Retrieving body of each webpage...`
   );

--- a/backend/src/tasks/test/s3-client.test.ts
+++ b/backend/src/tasks/test/s3-client.test.ts
@@ -1,0 +1,41 @@
+import S3Client from '../s3-client';
+
+const getObject = jest.fn();
+
+jest.mock('aws-sdk', () => ({
+  S3: jest.fn().mockImplementation(() => ({
+    getObject: (e) => ({
+      promise: getObject
+    })
+  }))
+}));
+
+describe('getWebpageBody', () => {
+  test('success', async () => {
+    getObject.mockImplementationOnce(async () => {
+      return { Body: 'test body' };
+    });
+    const client = new S3Client();
+    const body = await client.getWebpageBody('test_s3_key');
+    expect(body).toEqual('test body');
+  });
+  test('404 not found should silently return nothing', async () => {
+    getObject.mockImplementationOnce(async () => {
+      throw {
+        code: 'NoSuchKey',
+        region: null,
+        time: new Date('2020-10-02T13:47:23.164Z'),
+        requestId: '88A469CA3B9DE7A6',
+        extendedRequestId:
+          'Boj3K6QNJJlzoqv/B3U+juIeFP/kfYz+Wtj4xMH+Gm8DZB5uUy2YSpsK4x5c24toiYDHGKXl0vo=',
+        cfId: undefined,
+        statusCode: 404,
+        retryable: false,
+        retryDelay: 5.606855739193417
+      };
+    });
+    const client = new S3Client();
+    const body = await client.getWebpageBody('test_s3_key');
+    expect(body).toEqual('');
+  });
+});

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -120,6 +120,15 @@ resource "aws_iam_role_policy" "worker_task_role_policy" {
         "Resource": [
           "${aws_s3_bucket.webscraper_bucket.arn}/*"
         ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+          "s3:ListBucket"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.webscraper_bucket.arn}"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes #643. This was due to two problems:
- When the S3 file doesn't exist in the bucket, it currently just crashes. This PR makes it just return an empty body in those cases.
- The worker doesn't have the "ListObjects" permission for the bucket, so a 404 will show up as a 403 error. This PR adds in that permission, so a 404 error is properly shown.

Also, changes searchSync to only sync 100 webpages at a time, because it appears that the batch size of 500 is still too large for a single t2.micro ES instance to handle at all.