### PR TITLE
fix: broken search for webpage_body when search term is empty

### DIFF
--- a/frontend/src/pages/Search/SearchProvider/buildRequest.js
+++ b/frontend/src/pages/Search/SearchProvider/buildRequest.js
@@ -31,7 +31,7 @@ function buildChildMatch(searchTerm) {
         fields: ['webpage_body']
       }
     }
-    : {};
+    : { match_all: {} };
 }
 
 /*


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

explicitly match_all when search term is empty in buildChildMatch for webpage search

## 💭 Motivation and Context

Was getting this error when search term is empty string (initial page load / all results). @epicfaace let me know if I missed something. This is the backend error I was getting causing a 500.

![image](https://user-images.githubusercontent.com/36460150/95087335-8e57c800-06ef-11eb-98c6-8b4d77b85262.png)


## 🧪 Testing

Visit search page with empty filter

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
