### PR TITLE
Perform searchSync in chunks

### DIFF
--- a/backend/src/tasks/search-sync.ts
+++ b/backend/src/tasks/search-sync.ts
@@ -4,8 +4,13 @@ import { In } from 'typeorm';
 import ESClient, { WebpageRecord } from './es-client';
 import S3Client from './s3-client';
 import PQueue from 'p-queue';
+import { chunk } from 'lodash';
 
-const MAX_RESULTS = 500;
+/**
+ * Chunk sizes. These values are small during testing to facilitate testing.
+ */
+export const DOMAIN_CHUNK_SIZE = typeof jest === 'undefined' ? 300 : 10;
+export const WEBPAGE_CHUNK_SIZE = typeof jest === 'undefined' ? 100 : 5;
 
 export const handler = async (commandOptions: CommandOptions) => {
   const { organizationId, domainId } = commandOptions;
@@ -29,8 +34,7 @@ export const handler = async (commandOptions: CommandOptions) => {
       'COUNT(CASE WHEN services.updatedAt > domain.syncedAt THEN 1 END) >= 1'
     )
     .groupBy('domain.id, organization.id, vulnerabilities.id, services.id')
-    .select(['domain.id'])
-    .take(MAX_RESULTS);
+    .select(['domain.id']);
 
   if (organizationId) {
     // This parameter is used for testing only
@@ -38,20 +42,23 @@ export const handler = async (commandOptions: CommandOptions) => {
   }
 
   const domainIds = (await qs.getMany()).map((e) => e.id);
-
+  console.log(`Got ${domainIds.length} domains.`);
   if (domainIds.length) {
-    const domains = await Domain.find({
-      where: { id: In(domainIds) },
-      relations: ['services', 'organization', 'vulnerabilities']
-    });
-    console.log(`Syncing ${domains.length} domains...`);
-    await client.updateDomains(domains);
+    const domainIdChunks = chunk(domainIds, DOMAIN_CHUNK_SIZE);
+    for (const domainIdChunk of domainIdChunks) {
+      const domains = await Domain.find({
+        where: { id: In(domainIdChunk) },
+        relations: ['services', 'organization', 'vulnerabilities']
+      });
+      console.log(`Syncing ${domains.length} domains...`);
+      await client.updateDomains(domains);
 
-    await Domain.createQueryBuilder('domain')
-      .update(Domain)
-      .set({ syncedAt: new Date(Date.now()) })
-      .where({ id: In(domains.map((e) => e.id)) })
-      .execute();
+      await Domain.createQueryBuilder('domain')
+        .update(Domain)
+        .set({ syncedAt: new Date(Date.now()) })
+        .where({ id: In(domains.map((e) => e.id)) })
+        .execute();
+    }
     console.log('Domain sync complete.');
   } else {
     console.log('Not syncing any domains.');
@@ -61,7 +68,6 @@ export const handler = async (commandOptions: CommandOptions) => {
   const qs_ = Webpage.createQueryBuilder('webpage').where(
     '(webpage.updatedAt > webpage.syncedAt OR webpage.syncedAt is null)'
   );
-  // .orWhere('');
 
   if (domainId) {
     // This parameter is used for testing only
@@ -70,36 +76,37 @@ export const handler = async (commandOptions: CommandOptions) => {
 
   // The response actually has keys "webpage_id", "webpage_createdAt", etc.
   const s3Client = new S3Client();
-  const queue = new PQueue({ concurrency: 10 });
-  const webpages: WebpageRecord[] = await qs_.take(100).execute();
-  console.log(
-    `Got ${webpages.length} webpages. Retrieving body of each webpage...`
-  );
-  for (const i in webpages) {
-    const webpage = webpages[i];
-    if (webpage.webpage_s3Key) {
-      queue.add(async () => {
-        webpage.webpage_body = await s3Client.getWebpageBody(
-          webpage.webpage_s3Key
-        );
-        if (Number(i) % 100 == 0) {
-          console.log(`Finished: ${i}`);
-        }
-      });
-    }
-  }
-  await queue.onIdle();
+  const webpages: WebpageRecord[] = await qs_.execute();
+  console.log(`Got ${webpages.length} webpages.`);
 
   if (webpages.length) {
-    console.log(`Syncing ${webpages.length} webpages...`);
-    const results = await client.updateWebpages(webpages);
-    console.warn(results);
+    const webpageChunks = chunk(webpages, WEBPAGE_CHUNK_SIZE);
+    for (const webpageChunk of webpageChunks) {
+      console.log(`Syncing ${webpageChunk.length} webpages...`);
+      const queue = new PQueue({ concurrency: 10 });
+      for (const i in webpageChunk) {
+        const webpage = webpageChunk[i];
+        if (webpage.webpage_s3Key) {
+          queue.add(async () => {
+            webpage.webpage_body = await s3Client.getWebpageBody(
+              webpage.webpage_s3Key
+            );
+            if (Number(i) % 100 == 0) {
+              console.log(`Finished getting contents from S3: ${i}`);
+            }
+          });
+        }
+      }
+      await queue.onIdle();
+      await client.updateWebpages(webpageChunk);
 
-    await Webpage.createQueryBuilder('webpage')
-      .update(Webpage)
-      .set({ syncedAt: new Date(Date.now()) })
-      .where({ id: In(webpages.map((e) => e.webpage_id)) })
-      .execute();
+      await Webpage.createQueryBuilder('webpage')
+        .update(Webpage)
+        .set({ syncedAt: new Date(Date.now()) })
+        .where({ id: In(webpageChunk.map((e) => e.webpage_id)) })
+        .execute();
+    }
+
     console.log('Webpage sync complete.');
   } else {
     console.log('Not syncing any webpages.');

--- a/backend/src/tasks/test/es-client.test.ts
+++ b/backend/src/tasks/test/es-client.test.ts
@@ -1,0 +1,48 @@
+import { connectToDatabase, Domain, Webpage } from '../../models';
+import ESClient from '../es-client';
+
+const bulk = jest.fn(() => ({}));
+jest.mock('@elastic/elasticsearch', () => {
+  class Client {
+    helpers = {
+      bulk
+    };
+  }
+  return { Client };
+});
+
+let domain;
+let webpage;
+
+beforeAll(async () => {
+  await connectToDatabase();
+  domain = Domain.create({
+    name: 'first_file_testdomain5',
+    ip: '45.79.207.117'
+  });
+  webpage = Webpage.create({
+    domain,
+    url: 'https://cisa.gov/123',
+    status: 200,
+    updatedAt: new Date('9999-08-23T03:36:57.231Z'),
+    s3Key: 'testS3key'
+  });
+});
+
+describe('updateDomains', () => {
+  test('test', async () => {
+    const client = new ESClient();
+    await client.updateDomains(Array(1).fill(domain));
+    expect(bulk).toBeCalledTimes(1);
+    expect((bulk.mock.calls[0] as any)[0].datasource.length).toEqual(1);
+  });
+});
+
+describe('updateWebpages', () => {
+  test('test', async () => {
+    const client = new ESClient();
+    await client.updateWebpages(Array(1).fill(webpage));
+    expect(bulk).toBeCalledTimes(1);
+    expect((bulk.mock.calls[0] as any)[0].datasource.length).toEqual(1);
+  });
+});


### PR DESCRIPTION
Each searchSync scan now performs the syncing in chunks, and repeatedly does so until all domains / webpages have been synced.

This will fix the current issues we're having with our elasticsearch domains running out of memory on prod with the searchSync scans.