### PR TITLE
Scale up elasticsearch on prod

### DIFF
--- a/infrastructure/es.tf
+++ b/infrastructure/es.tf
@@ -7,8 +7,8 @@ resource "aws_elasticsearch_domain" "es" {
   elasticsearch_version = "7.7"
 
   cluster_config {
-    instance_type            = "t2.small.elasticsearch"
-    instance_count           = 1
+    instance_type            = var.es_instance_type
+    instance_count           = var.es_instance_count
     dedicated_master_enabled = false
 
     # Enable for prod:

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -36,3 +36,5 @@ user_pool_domain                  = "crossfeed"
 ssm_user_pool_id                  = "/crossfeed/staging/USER_POOL_ID"
 ssm_user_pool_client_id           = "/crossfeed/staging/USER_POOL_CLIENT_ID"
 ses_support_email                 = "support@crossfeed.cyber.dhs.gov"
+es_instance_type                  = "t3.small.elasticsearch"
+es_instance_count                 = 3

--- a/infrastructure/stage.tfvars
+++ b/infrastructure/stage.tfvars
@@ -36,3 +36,5 @@ user_pool_domain                  = "crossfeed-staging"
 ssm_user_pool_id                  = "/crossfeed/staging/USER_POOL_ID"
 ssm_user_pool_client_id           = "/crossfeed/staging/USER_POOL_CLIENT_ID"
 ses_support_email                 = "support@staging.crossfeed.cyber.dhs.gov"
+es_instance_type                  = "t2.micro.elasticsearch"
+es_instance_count                 = 1

--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -187,3 +187,13 @@ variable ses_support_email {
   type    = string
   default = "support@staging.crossfeed.cyber.dhs.gov"
 }
+
+variable es_instance_type {
+  type    = string
+  default = "t2.micro.elasticsearch"
+}
+
+variable es_instance_count {
+  type    = number
+  default = 1
+}


### PR DESCRIPTION
Scale down elasticsearch on staging and scale up elasticsearch on prod. Fixes #571

Previously, we were paying for 2 t2.small.elasticsearch clusters -- this is 25.92 * 2 = $51.84 / month.

Now, we'll be paying for 1 t2.micro.elasticsearch and 3 t3.small.elasticsearch clusters -- this is 12.96 + 25.92 * 3 = $90.72 / month.