### PR TITLE
Use t2.small.elasticsearch for staging

### DIFF
--- a/infrastructure/stage.tfvars
+++ b/infrastructure/stage.tfvars
@@ -36,5 +36,5 @@ user_pool_domain                  = "crossfeed-staging"
 ssm_user_pool_id                  = "/crossfeed/staging/USER_POOL_ID"
 ssm_user_pool_client_id           = "/crossfeed/staging/USER_POOL_CLIENT_ID"
 ses_support_email                 = "support@staging.crossfeed.cyber.dhs.gov"
-es_instance_type                  = "t2.micro.elasticsearch"
+es_instance_type                  = "t2.small.elasticsearch"
 es_instance_count                 = 1


### PR DESCRIPTION
Didn't realize that "The t2.micro.elasticsearch instance type supports only Elasticsearch 1.5 and 2.3."