### PR TITLE
Make domain.organization nullable

### DIFF
--- a/backend/src/models/domain.ts
+++ b/backend/src/models/domain.ts
@@ -71,7 +71,7 @@ export class Domain extends BaseEntity {
   @OneToMany((type) => Webpage, (webpage) => webpage.domain)
   webpages: Service[];
 
-  @ManyToOne((type) => Organization, { onDelete: 'CASCADE', nullable: false })
+  @ManyToOne((type) => Organization, { onDelete: 'CASCADE', nullable: true })
   organization: Organization;
 
   @Column({


### PR DESCRIPTION
Right now, prod is down because when we run syncdb, we get the error `column \"organizationId\" contains null values`. Turns out we have 2491606 domains with a null organizationId, so for now, let's just make organizationId nullable so we can get production to work.