### PR TITLE
Add sitemap display

### DIFF
--- a/frontend/src/components/DomainDetails.tsx
+++ b/frontend/src/components/DomainDetails.tsx
@@ -134,9 +134,22 @@ export const DomainDetails: React.FC<Props> = (props) => {
     }
     return tree;
   };
+
   const [hiddenRows, setHiddenRows] = React.useState<{
     [key: string]: boolean;
   }>({});
+
+  const formatBytes = (bytes: number, decimals = 2): string => {
+    if (bytes === 0) return '0 Bytes';
+
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+  };
 
   const generateWebpageList = (tree: any, prefix = '') => {
     return (
@@ -181,7 +194,9 @@ export const DomainDetails: React.FC<Props> = (props) => {
             <ListItem button divider={true} key={page.url}>
               <ListItemText
                 primary={(prefix ? '' : '/') + split.pop()}
-                secondary={page.status + ' • ' + page.responseSize + ' bytes'}
+                secondary={
+                  page.status + ' • ' + formatBytes(page.responseSize ?? 0, 1)
+                }
               ></ListItemText>
             </ListItem>
           );

--- a/frontend/src/components/DomainDetails.tsx
+++ b/frontend/src/components/DomainDetails.tsx
@@ -191,7 +191,12 @@ export const DomainDetails: React.FC<Props> = (props) => {
           const parsed = new URL(page.url);
           const split = parsed.pathname.split('/');
           return (
-            <ListItem button divider={true} key={page.url}>
+            <ListItem
+              button
+              divider={true}
+              key={page.url}
+              onClick={() => window.open(page.url, '_blank')}
+            >
               <ListItemText
                 primary={(prefix ? '' : '/') + split.pop()}
                 secondary={

--- a/frontend/src/components/DomainDetails.tsx
+++ b/frontend/src/components/DomainDetails.tsx
@@ -6,14 +6,24 @@ import {
   Accordion,
   AccordionSummary,
   Typography,
-  AccordionDetails
+  AccordionDetails,
+  List,
+  ListItem,
+  ListItemText,
+  Collapse
 } from '@material-ui/core';
-import { ExpandMore, Launch as LinkOffIcon } from '@material-ui/icons';
+import {
+  ExpandLess,
+  ExpandMore,
+  Launch as LinkOffIcon
+} from '@material-ui/icons';
 import { Domain } from 'types';
 import { useDomainApi } from 'hooks';
 import { DefinitionList } from './DefinitionList';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { stateMap } from 'pages/Vulnerabilities/Vulnerabilities';
+import { Webpage } from 'types/webpage';
+import { isNamedImports, isNamespaceExport } from 'typescript';
 
 interface Props {
   domainId: string;
@@ -106,6 +116,79 @@ export const DomainDetails: React.FC<Props> = (props) => {
     return ret;
   }, [domain]);
 
+  const generateWebpageTree = (pages: Webpage[]) => {
+    const tree: any = {};
+    for (const page of pages) {
+      const url = new URL(page.url);
+      const parts = url.pathname.split('/').filter((path) => path !== '');
+      let root = tree;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (parts[i] in root) root = root[parts[i]];
+        else {
+          root[parts[i]] = {};
+          root = root[parts[i]];
+        }
+      }
+      root[parts[parts.length - 1]] = page;
+    }
+    return tree;
+  };
+  const [hiddenRows, setHiddenRows] = React.useState<{
+    [key: string]: boolean;
+  }>({});
+
+  const generateWebpageList = (tree: any, prefix = '') => {
+    return (
+      <List
+        className={`${classes.listRoot}${prefix ? ' ' + classes.nested : ''}`}
+      >
+        {Object.keys(tree).map((key) => {
+          const isWebpage =
+            'url' in tree[key] && typeof tree[key]['url'] === 'string';
+          if (!isWebpage) {
+            let newPrefix = prefix + '/' + key;
+            return (
+              <>
+                <ListItem
+                  button
+                  onClick={() => {
+                    setHiddenRows((hiddenRows: any) => {
+                      hiddenRows[newPrefix] =
+                        newPrefix in hiddenRows ? !hiddenRows[newPrefix] : true;
+                      return { ...hiddenRows };
+                    });
+                  }}
+                  key={newPrefix}
+                >
+                  <ListItemText primary={(prefix ? '' : '/') + key + '/'} />
+                  {hiddenRows[newPrefix] ? <ExpandLess /> : <ExpandMore />}
+                </ListItem>
+                <Collapse
+                  in={!hiddenRows[newPrefix]}
+                  timeout="auto"
+                  unmountOnExit
+                >
+                  {generateWebpageList(tree[key], newPrefix)}
+                </Collapse>
+              </>
+            );
+          }
+          const page = tree[key] as Webpage;
+          const parsed = new URL(page.url);
+          const split = parsed.pathname.split('/');
+          return (
+            <ListItem button divider={true} key={page.url}>
+              <ListItemText
+                primary={(prefix ? '' : '/') + split.pop()}
+                secondary={page.status + ' • ' + page.responseSize + ' bytes'}
+              ></ListItemText>
+            </ListItem>
+          );
+        })}
+      </List>
+    );
+  };
+
   if (!domain) {
     return null;
   }
@@ -114,6 +197,10 @@ export const DomainDetails: React.FC<Props> = (props) => {
     (domain.services.find((service) => service.port === 443)
       ? 'https://'
       : 'http://') + domain.name;
+
+  domain.webpages.sort((a, b) => (a.url > b.url ? 1 : -1));
+  const webpageTree = generateWebpageTree(domain.webpages);
+  const webpageList = generateWebpageList(webpageTree);
 
   return (
     <Paper classes={{ root: classes.root }}>
@@ -266,6 +353,12 @@ export const DomainDetails: React.FC<Props> = (props) => {
             ))}
           </div>
         )}
+        {domain.webpages.length > 0 && (
+          <div className={classes.section}>
+            <h4 className={classes.subtitle}>Site Map</h4>
+            {webpageList}
+          </div>
+        )}
       </div>
     </Paper>
   );
@@ -329,5 +422,12 @@ const useStyles = makeStyles((theme) => ({
     flex: '1 1 15%',
     textOverflow: 'hidden',
     textAlign: 'right'
+  },
+  listRoot: {
+    width: '100%',
+    backgroundColor: theme.palette.background.paper
+  },
+  nested: {
+    paddingLeft: theme.spacing(2)
   }
 }));


### PR DESCRIPTION
Adds a sitemap display to a domain, which displays the sitemap as a nested tree with collapsable sections:

<img width="536" alt="Screen Shot 2020-10-14 at 5 43 33 PM" src="https://user-images.githubusercontent.com/7061968/96060940-c32df280-0e46-11eb-8692-93254b55c625.png">


Fixes #664.