### PR TITLE
Remove ondelete for discoveredBy

### DIFF
--- a/backend/src/models/domain.ts
+++ b/backend/src/models/domain.ts
@@ -46,10 +46,7 @@ export class Domain extends BaseEntity {
   })
   fromRootDomain: string;
 
-  @ManyToOne((type) => Scan, {
-    onDelete: 'SET NULL',
-    onUpdate: 'CASCADE'
-  })
+  @ManyToOne((type) => Scan)
   discoveredBy: Scan;
 
   @Column({

--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -78,10 +78,7 @@ export class Service extends BaseEntity {
   })
   domain: Domain;
 
-  @ManyToOne((type) => Scan, {
-    onDelete: 'SET NULL',
-    onUpdate: 'CASCADE'
-  })
+  @ManyToOne((type) => Scan)
   discoveredBy: Scan;
 
   @Column()

--- a/backend/src/models/webpage.ts
+++ b/backend/src/models/webpage.ts
@@ -36,10 +36,7 @@ export class Webpage extends BaseEntity {
   })
   domain: Domain;
 
-  @ManyToOne((type) => Scan, {
-    onDelete: 'SET NULL',
-    onUpdate: 'CASCADE'
-  })
+  @ManyToOne((type) => Scan)
   discoveredBy: Scan;
 
   @Column({


### PR DESCRIPTION
Deleting a scan can time out as the current onDelete actions take a while. This removes those to improve performance.