### PR TITLE
Scheduler bugfix

### DIFF
--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -189,7 +189,7 @@ class Scheduler {
         }
       }
       //if atleast 1 new scan task was launched for this scan, update the scan
-      if (this.numLaunchedTasks > prev_numLaunchedTasks ) {
+      if (this.numLaunchedTasks > prev_numLaunchedTasks) {
         scan.lastRun = new Date();
         scan.manualRunPending = false;
         await scan.save();

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -160,6 +160,8 @@ class Scheduler {
 
   async run() {
     for (const scan of this.scans) {
+      const prev_numLaunchedTasks = this.numLaunchedTasks;
+
       if (!SCAN_SCHEMA[scan.name]) {
         console.error('Invalid scan name ', scan.name);
         continue;
@@ -186,7 +188,8 @@ class Scheduler {
           await this.launchScanTask({ organization, scan });
         }
       }
-      if (this.numLaunchedTasks > 0) {
+      //if atleast 1 new scan task was launched for this scan, update the scan
+      if (this.numLaunchedTasks > prev_numLaunchedTasks ) {
         scan.lastRun = new Date();
         scan.manualRunPending = false;
         await scan.save();

--- a/backend/src/tasks/test/scheduler.test.ts
+++ b/backend/src/tasks/test/scheduler.test.ts
@@ -715,4 +715,53 @@ describe('scheduler', () => {
 
     expect(runCommand).toHaveBeenCalledTimes(0);
   });
+  test('should not change lastRun time of the second scan if the first scan runs', async () => {
+    //Make scan run before scan2. Scan2 should have already run, and doesn't need to run again.
+    //The scheduler should not change scan2.lastRun during its second call
+    const scan = await Scan.create({
+      name: 'findomain',
+      arguments: {},
+      frequency: 1,
+      lastRun: new Date(0)
+    }).save();
+    let scan2 = await Scan.create({
+      name: 'findomain',
+      arguments: {},
+      frequency: 999,
+      lastRun: new Date()
+    }).save();
+    const organization = await Organization.create({
+      name: 'test-' + Math.random(),
+      rootDomains: ['test-' + Math.random()],
+      ipBlocks: [],
+      isPassive: false
+    }).save();
+
+    //run scheduler on scan2, this establishes a finished recent scantask for scan2
+    await scheduler(
+      {
+        scanIds: [scan2.id],
+        organizationId: organization.id
+      },
+      {} as any,
+      () => void 0
+    );
+    scan2 = (await Scan.findOne(scan2.id))!;
+    expect(runCommand).toHaveBeenCalledTimes(1);
+
+    //run scheduler on both scans, scan should be run, but scan2 should be skipped
+    await scheduler(
+      {
+        scanIds: [scan.id, scan2.id],
+        organizationId: organization.id
+      },
+      {} as any,
+      () => void 0
+    );
+    expect(runCommand).toHaveBeenCalledTimes(2);
+
+    const newscan2 = (await Scan.findOne(scan2.id))!;
+    //expect scan2's lastRun was not edited during the second call to scheduler
+    expect(newscan2.lastRun).toEqual(scan2.lastRun);
+  });
 });


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

This is a fix to the bug in the scheduler that was changing the lastRun variable in scans that had not been run yet.

<!--- Describe your changes in detail -->

For each scan that is checked in the run() function, a variable tracks the previous number of launched tasks. Then in the final if statement in run(), it checks to see if there is difference between the previous number of launched tasks and the current number. If there is, then that scan specifically has been run and it's lastRun variable can be updated, along with manualRunPending.


## 💭 Motivation and Context
See issue #713 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All previous tests pass. Through dev tools and console logs, I verified that the bug no longer occurs.
Test added to scheduler.test that sets the proper conditions for the bug and ensures it's fixed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
