### PR TITLE
Remove unneeded code for crossfeed-token

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -170,8 +170,6 @@ app.use(
     if (user.userType !== 'globalAdmin') {
       return res.status(401).send('Unauthorized');
     }
-    // Don't forward the crossfeed-token cookie to the proxy
-    delete req.cookies['crossfeed-token'];
     return next();
   },
   matomoProxy


### PR DESCRIPTION
This code actually has no effect, as calling `delete` on the token will not prevent the original `Cookie` header from being sent over to other middleware.

This code (which is already there) already prevents `crossfeed-token` from being sent to Matomo:

https://github.com/cisagov/crossfeed/blob/a8f86bc0b18fc0a62a0dcae53e11fd640a100626/backend/src/api/app.ts#L124-L132