### PR TITLE
Give table rows a max height

### DIFF
--- a/frontend/src/components/Table/TableBody.tsx
+++ b/frontend/src/components/Table/TableBody.tsx
@@ -25,7 +25,9 @@ export const TableBody = <T extends object>({
                 const { key, ...rest } = cell.getCellProps();
                 return (
                   <td key={key} {...rest} className={classes.td}>
+                    <div>
                     {cell.render("Cell")}
+                    </div>
                   </td>
                 );
               })}

--- a/frontend/src/components/Table/styles.module.scss
+++ b/frontend/src/components/Table/styles.module.scss
@@ -31,6 +31,10 @@
   border-color: white;
   text-overflow: ellipsis;
   white-space: normal;
+  > div {
+    max-height: 50px;
+    overflow: auto;
+  }
 }
 
 .subComponentTd {


### PR DESCRIPTION
This way, the organizations table view will look like this, and be easier to scroll through:

![image](https://user-images.githubusercontent.com/1689183/96357226-2e85f780-10c7-11eb-94cf-eaed20bf8b26.png)
