### PR TITLE
Disable ES audit logs

### DIFF
--- a/infrastructure/es.tf
+++ b/infrastructure/es.tf
@@ -73,11 +73,6 @@ POLICY
     log_type                 = "SEARCH_SLOW_LOGS"
   }
 
-  log_publishing_options {
-    cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_audit.arn
-    log_type                 = "AUDIT_LOGS"
-  }
-
   ebs_options {
     ebs_enabled = true
     volume_size = 10
@@ -129,14 +124,6 @@ resource "aws_cloudwatch_log_group" "es_index_slow" {
 
 resource "aws_cloudwatch_log_group" "es_search_slow" {
   name = "crossfeed-${var.stage}-es-search-slow"
-  tags = {
-    Project = var.project
-    Stage   = var.stage
-  }
-}
-
-resource "aws_cloudwatch_log_group" "es_audit" {
-  name = "crossfeed-${var.stage}-es-audit"
   tags = {
     Project = var.project
     Stage   = var.stage


### PR DESCRIPTION
Temporarily revert until we can fix the error, "ValidationException: audit log publishing cannot be enabled as you do not have advanced security options configured."