### PR TITLE
Revert code textbox change

### DIFF
--- a/frontend/src/pages/AuthLogin/AuthLogin.tsx
+++ b/frontend/src/pages/AuthLogin/AuthLogin.tsx
@@ -16,7 +16,7 @@ I18n.putVocabulariesForLanguage("en-US", {
   [Translations.CONFIRM_TOTP_CODE]: "Enter 2FA Code",
   [Translations.CONFIRM_SIGN_UP_CODE_LABEL]: "Email Confirmation Code",
   [Translations.CONFIRM_SIGN_UP_CODE_PLACEHOLDER]: "Enter code sent to your email address",
-  [Translations.CODE_LABEL]: "Enter code sent to your email address:", // Reset password code
+  [Translations.CODE_LABEL]: "Enter code:", // Reset password code
   [Translations.LESS_THAN_TWO_MFA_VALUES_MESSAGE]: ""
 });
 

--- a/frontend/src/pages/AuthLogin/AuthLogin.tsx
+++ b/frontend/src/pages/AuthLogin/AuthLogin.tsx
@@ -16,7 +16,7 @@ I18n.putVocabulariesForLanguage("en-US", {
   [Translations.CONFIRM_TOTP_CODE]: "Enter 2FA Code",
   [Translations.CONFIRM_SIGN_UP_CODE_LABEL]: "Email Confirmation Code",
   [Translations.CONFIRM_SIGN_UP_CODE_PLACEHOLDER]: "Enter code sent to your email address",
-  [Translations.CODE_LABEL]: "Enter code:", // Reset password code
+  [Translations.CODE_LABEL]: "Enter code:", // 2FA prompt and reset password label
   [Translations.LESS_THAN_TWO_MFA_VALUES_MESSAGE]: ""
 });
 


### PR DESCRIPTION
Looks like Amplify uses the same label for the 2FA prompt screen and the "Reset Password" screen...

![image](https://user-images.githubusercontent.com/1689183/96394144-488b0d00-118f-11eb-8584-384bd625b06b.png)
