### PR TITLE
Fix MATOMO_URL for prod

### DIFF
--- a/backend/env.yml
+++ b/backend/env.yml
@@ -56,6 +56,7 @@ prod:
   WORKER_SIGNATURE_PUBLIC_KEY: ${ssm:/crossfeed/prod/WORKER_SIGNATURE_PUBLIC_KEY}
   ELASTICSEARCH_ENDPOINT: ${ssm:/crossfeed/prod/ELASTICSEARCH_ENDPOINT}
   REACT_APP_TERMS_VERSION: ${ssm:/crossfeed/prod/REACT_APP_TERMS_VERSION}
+  MATOMO_URL: http://matomo.crossfeed.local
 
 staging-vpc:
   securityGroupIds:


### PR DESCRIPTION
This is causing all endpoints on prod to fail with:

```
Mon Oct 19 02:54:49 UTC 2020 : Lambda execution failed with status 200 due to customer function error: [HPM] Missing "target" option. Example: {target: "http://www.example.org"}. Lambda request id: 474e74e7-7222-4364-b0f5-886d71814ad6
```