### PR TITLE
Make elasticsearch indexing more resilient

### DIFF
--- a/backend/src/tasks/es-client.ts
+++ b/backend/src/tasks/es-client.ts
@@ -91,6 +91,13 @@ class ESClient {
       });
       console.log(`Created index ${DOMAINS_INDEX}.`);
     }
+    await this.client.indices.putSettings({
+      index: DOMAINS_INDEX,
+      body: {
+        settings: { refresh_interval: '60s' }
+      }
+    });
+    console.log(`Updated settings for index ${DOMAINS_INDEX}.`);
   }
 
   excludeFields = (domain: Domain) => {

--- a/backend/src/tasks/helpers/saveWebpagesToDb.ts
+++ b/backend/src/tasks/helpers/saveWebpagesToDb.ts
@@ -1,4 +1,5 @@
 import { plainToClass } from 'class-transformer';
+import pRetry from 'p-retry';
 import { connectToDatabase, Webpage } from '../../models';
 import ESClient from '../es-client';
 import { ScraperItem } from '../webscraper';
@@ -43,23 +44,30 @@ export default async (scrapedWebpages: ScraperItem[]): Promise<void> => {
   }
   console.log('Saving webpages to elasticsearch...');
   const client = new ESClient();
-  client.updateWebpages(
-    scrapedWebpages.map((e) => {
-      const insertedWebpage = urlToInsertedWebpage[e.url];
-      return {
-        webpage_id: insertedWebpage.id,
-        webpage_createdAt: insertedWebpage.createdAt,
-        webpage_updatedAt: insertedWebpage.updatedAt,
-        webpage_syncedAt: insertedWebpage.syncedAt,
-        webpage_lastSeen: insertedWebpage.lastSeen,
-        webpage_url: insertedWebpage.url,
-        webpage_status: insertedWebpage.status,
-        webpage_domainId: e.domain!.id,
-        webpage_discoveredById: e.discoveredBy!.id,
-        webpage_responseSize: insertedWebpage.responseSize,
-        webpage_headers: insertedWebpage.headers,
-        webpage_body: e.body
-      };
-    })
+  await pRetry(
+    () =>
+      client.updateWebpages(
+        scrapedWebpages.map((e) => {
+          const insertedWebpage = urlToInsertedWebpage[e.url];
+          return {
+            webpage_id: insertedWebpage.id,
+            webpage_createdAt: insertedWebpage.createdAt,
+            webpage_updatedAt: insertedWebpage.updatedAt,
+            webpage_syncedAt: insertedWebpage.syncedAt,
+            webpage_lastSeen: insertedWebpage.lastSeen,
+            webpage_url: insertedWebpage.url,
+            webpage_status: insertedWebpage.status,
+            webpage_domainId: e.domain!.id,
+            webpage_discoveredById: e.discoveredBy!.id,
+            webpage_responseSize: insertedWebpage.responseSize,
+            webpage_headers: insertedWebpage.headers,
+            webpage_body: e.body
+          };
+        })
+      ),
+    {
+      retries: 5,
+      randomize: true
+    }
   );
 };

--- a/infrastructure/es.tf
+++ b/infrastructure/es.tf
@@ -75,7 +75,7 @@ POLICY
 
   ebs_options {
     ebs_enabled = true
-    volume_size = 10
+    volume_size = 20
   }
 
   tags = {


### PR DESCRIPTION
Helps with the bulk rejections that we are seeing on dev / prod.

- update refresh_interval to 60s to make indexing less memory-intensive (default is 1s)
- increase ES volume size
- use randomized retries when syncing webpages to elasticsearch

Fixes #744.