### PR TITLE
Make elasticsearch even more reliable

### DIFF
--- a/backend/src/tasks/es-client.ts
+++ b/backend/src/tasks/es-client.ts
@@ -94,7 +94,7 @@ class ESClient {
     await this.client.indices.putSettings({
       index: DOMAINS_INDEX,
       body: {
-        settings: { refresh_interval: '60s' }
+        settings: { refresh_interval: '300s' }
       }
     });
     console.log(`Updated settings for index ${DOMAINS_INDEX}.`);

--- a/backend/src/tasks/helpers/saveWebpagesToDb.ts
+++ b/backend/src/tasks/helpers/saveWebpagesToDb.ts
@@ -70,7 +70,7 @@ export default async (scrapedWebpages: ScraperItem[]): Promise<void> => {
         }).filter(e => e) as WebpageRecord[]
       ),
     {
-      retries: 5,
+      retries: 10,
       randomize: true
     }
   );

--- a/backend/src/tasks/helpers/saveWebpagesToDb.ts
+++ b/backend/src/tasks/helpers/saveWebpagesToDb.ts
@@ -47,27 +47,29 @@ export default async (scrapedWebpages: ScraperItem[]): Promise<void> => {
   await pRetry(
     () =>
       client.updateWebpages(
-        scrapedWebpages.map((e) => {
-          const insertedWebpage = urlToInsertedWebpage[e.url];
-          if (!insertedWebpage) {
-            console.log(`Inserted webpage not found for URL: ${e.url}`)
-            return undefined;
-          }
-          return {
-            webpage_id: insertedWebpage.id,
-            webpage_createdAt: insertedWebpage.createdAt,
-            webpage_updatedAt: insertedWebpage.updatedAt,
-            webpage_syncedAt: insertedWebpage.syncedAt,
-            webpage_lastSeen: insertedWebpage.lastSeen,
-            webpage_url: insertedWebpage.url,
-            webpage_status: insertedWebpage.status,
-            webpage_domainId: e.domain!.id,
-            webpage_discoveredById: e.discoveredBy!.id,
-            webpage_responseSize: insertedWebpage.responseSize,
-            webpage_headers: insertedWebpage.headers,
-            webpage_body: e.body
-          };
-        }).filter(e => e) as WebpageRecord[]
+        scrapedWebpages
+          .map((e) => {
+            const insertedWebpage = urlToInsertedWebpage[e.url];
+            if (!insertedWebpage) {
+              console.log(`Inserted webpage not found for URL: ${e.url}`);
+              return undefined;
+            }
+            return {
+              webpage_id: insertedWebpage.id,
+              webpage_createdAt: insertedWebpage.createdAt,
+              webpage_updatedAt: insertedWebpage.updatedAt,
+              webpage_syncedAt: insertedWebpage.syncedAt,
+              webpage_lastSeen: insertedWebpage.lastSeen,
+              webpage_url: insertedWebpage.url,
+              webpage_status: insertedWebpage.status,
+              webpage_domainId: e.domain!.id,
+              webpage_discoveredById: e.discoveredBy!.id,
+              webpage_responseSize: insertedWebpage.responseSize,
+              webpage_headers: insertedWebpage.headers,
+              webpage_body: e.body
+            };
+          })
+          .filter((e) => e) as WebpageRecord[]
       ),
     {
       retries: 10,

--- a/backend/src/tasks/helpers/saveWebpagesToDb.ts
+++ b/backend/src/tasks/helpers/saveWebpagesToDb.ts
@@ -1,7 +1,7 @@
 import { plainToClass } from 'class-transformer';
 import pRetry from 'p-retry';
 import { connectToDatabase, Webpage } from '../../models';
-import ESClient from '../es-client';
+import ESClient, { WebpageRecord } from '../es-client';
 import { ScraperItem } from '../webscraper';
 
 /** Saves scraped webpages to the database, and also syncs them
@@ -49,6 +49,10 @@ export default async (scrapedWebpages: ScraperItem[]): Promise<void> => {
       client.updateWebpages(
         scrapedWebpages.map((e) => {
           const insertedWebpage = urlToInsertedWebpage[e.url];
+          if (!insertedWebpage) {
+            console.log(`Inserted webpage not found for URL: ${e.url}`)
+            return undefined;
+          }
           return {
             webpage_id: insertedWebpage.id,
             webpage_createdAt: insertedWebpage.createdAt,
@@ -63,7 +67,7 @@ export default async (scrapedWebpages: ScraperItem[]): Promise<void> => {
             webpage_headers: insertedWebpage.headers,
             webpage_body: e.body
           };
-        })
+        }).filter(e => e) as WebpageRecord[]
       ),
     {
       retries: 5,

--- a/backend/src/tasks/webscraper.ts
+++ b/backend/src/tasks/webscraper.ts
@@ -74,7 +74,9 @@ export const handler = async (commandOptions: CommandOptions) => {
   await new Promise((resolve, reject) => {
     console.log('Going to save webpages to the database...');
     let scrapedWebpages: ScraperItem[] = [];
-    readInterfaceStderr.on('line', (line) => console.error(line?.substring(0, 999)));
+    readInterfaceStderr.on('line', (line) =>
+      console.error(line?.substring(0, 999))
+    );
     readInterface.on('line', async (line) => {
       if (!line?.trim() || line.indexOf('database_output: ') === -1) {
         console.log(line);
@@ -103,7 +105,9 @@ export const handler = async (commandOptions: CommandOptions) => {
           if (scrapedWebpages.length === 0) {
             return;
           }
-          console.log(`Saving ${scrapedWebpages.length} webpages, starting with ${scrapedWebpages[0].url}...`);
+          console.log(
+            `Saving ${scrapedWebpages.length} webpages, starting with ${scrapedWebpages[0].url}...`
+          );
           await saveWebpagesToDb(scrapedWebpages);
           totalNumWebpages += scrapedWebpages.length;
           scrapedWebpages = [];

--- a/backend/src/tasks/webscraper.ts
+++ b/backend/src/tasks/webscraper.ts
@@ -10,7 +10,7 @@ import PQueue from 'p-queue';
 
 const WEBSCRAPER_DIRECTORY = '/app/worker/webscraper';
 const INPUT_PATH = path.join(WEBSCRAPER_DIRECTORY, 'domains.txt');
-const WEBPAGE_DB_BATCH_LENGTH = 100;
+const WEBPAGE_DB_BATCH_LENGTH = 10;
 
 // Sync this with backend/worker/webscraper/webscraper/items.py
 export interface ScraperItem {
@@ -74,7 +74,7 @@ export const handler = async (commandOptions: CommandOptions) => {
   await new Promise((resolve, reject) => {
     console.log('Going to save webpages to the database...');
     let scrapedWebpages: ScraperItem[] = [];
-    readInterfaceStderr.on('line', (line) => console.error(line));
+    readInterfaceStderr.on('line', (line) => console.error(line?.substring(0, 999)));
     readInterface.on('line', async (line) => {
       if (!line?.trim() || line.indexOf('database_output: ') === -1) {
         console.log(line);
@@ -85,7 +85,6 @@ export const handler = async (commandOptions: CommandOptions) => {
           line.indexOf('database_output: ') + 'database_output: '.length
         )
       );
-      console.log('got item', item.status, item.url);
       const domain = liveWebsitesMap[item.domain_name];
       if (!domain) {
         console.error(
@@ -104,7 +103,7 @@ export const handler = async (commandOptions: CommandOptions) => {
           if (scrapedWebpages.length === 0) {
             return;
           }
-          console.log(`Saving ${scrapedWebpages.length} webpages...`);
+          console.log(`Saving ${scrapedWebpages.length} webpages, starting with ${scrapedWebpages[0].url}...`);
           await saveWebpagesToDb(scrapedWebpages);
           totalNumWebpages += scrapedWebpages.length;
           scrapedWebpages = [];


### PR DESCRIPTION
Still having some issues with bulk requests getting throttled, especially when we have concurrent instances of webscraper running. This PR:

- Sets refresh_interval to 300s
- Indexes webpages in batches of 10, not 100
- Increases # of retries for webpage indexing
- prints less output (so logs are smaller, more concise)
- fixes a bug where scraper would crash when `insertedWebpage` is undefined (not sure when / why this is happening though)