### PR TITLE
Increase elasticsearch disk size

### DIFF
--- a/infrastructure/es.tf
+++ b/infrastructure/es.tf
@@ -75,7 +75,7 @@ POLICY
 
   ebs_options {
     ebs_enabled = true
-    volume_size = 20
+    volume_size = 100
   }
 
   tags = {


### PR DESCRIPTION
We ran out of space -- getting this error now in searchSync:

```
2020-10-20T12:06:49.924Z {
2020-10-20T12:06:49.924Z   type: 'cluster_block_exception',
2020-10-20T12:06:49.924Z   reason: 'index [domains-5] blocked by: [FORBIDDEN/8/index write (api)];'
2020-10-20T12:06:49.924Z } {
```