### PR TITLE
Fix URL display with trailing slashes

### DIFF
--- a/frontend/src/components/DomainDetails.tsx
+++ b/frontend/src/components/DomainDetails.tsx
@@ -29,6 +29,24 @@ interface Props {
   domainId: string;
 }
 
+export const generateWebpageTree = (pages: Webpage[]) => {
+  const tree: any = {};
+  for (const page of pages) {
+    const url = new URL(page.url);
+    const parts = url.pathname.split('/').filter((path) => path !== '');
+    let root = tree;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (parts[i] in root) root = root[parts[i]];
+      else {
+        root[parts[i]] = {};
+        root = root[parts[i]];
+      }
+    }
+    root[parts[parts.length - 1]] = page;
+  }
+  return tree;
+};
+
 export const DomainDetails: React.FC<Props> = (props) => {
   const { domainId } = props;
   const { getDomain } = useDomainApi(false);
@@ -117,24 +135,6 @@ export const DomainDetails: React.FC<Props> = (props) => {
     return ret;
   }, [domain]);
 
-  const generateWebpageTree = (pages: Webpage[]) => {
-    const tree: any = {};
-    for (const page of pages) {
-      const url = new URL(page.url);
-      const parts = url.pathname.split('/').filter((path) => path !== '');
-      let root = tree;
-      for (let i = 0; i < parts.length - 1; i++) {
-        if (parts[i] in root) root = root[parts[i]];
-        else {
-          root[parts[i]] = {};
-          root = root[parts[i]];
-        }
-      }
-      root[parts[parts.length - 1]] = page;
-    }
-    return tree;
-  };
-
   const [hiddenRows, setHiddenRows] = React.useState<{
     [key: string]: boolean;
   }>({});
@@ -189,7 +189,9 @@ export const DomainDetails: React.FC<Props> = (props) => {
           }
           const page = tree[key] as Webpage;
           const parsed = new URL(page.url);
-          const split = parsed.pathname.split('/');
+          const split = parsed.pathname
+            .replace(/\/$/, "") // Remove trailing slash
+            .split('/');
           return (
             <ListItem
               button

--- a/frontend/src/components/__tests__/__snapshots__/domainDetails.spec.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/domainDetails.spec.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateWebpageTree basic path 1`] = `
+Object {
+  "a": Object {
+    "b": Object {
+      "c": Object {
+        "url": "https://www.cisa.gov/a/b/c",
+      },
+    },
+  },
+}
+`;
+
+exports[`generateWebpageTree no path 1`] = `
+Object {
+  "undefined": Object {
+    "url": "https://www.cisa.gov/",
+  },
+}
+`;
+
+exports[`generateWebpageTree single path 1`] = `
+Object {
+  "a": Object {
+    "url": "https://www.cisa.gov/a",
+  },
+}
+`;
+
+exports[`generateWebpageTree trailing slash 1`] = `
+Object {
+  "a": Object {
+    "url": "https://www.cisa.gov/a/",
+  },
+}
+`;

--- a/frontend/src/components/__tests__/domainDetails.spec.tsx
+++ b/frontend/src/components/__tests__/domainDetails.spec.tsx
@@ -1,0 +1,43 @@
+import { generateWebpageTree } from 'components/DomainDetails';
+import React from 'react';
+import { render, fireEvent, testUser, testOrganization } from 'test-utils';
+import { Header } from '../Header';
+
+describe('generateWebpageTree', () => {
+    it('no path', () => {
+        const pages = [
+            {
+                url: "https://www.cisa.gov/"
+            }
+        ];
+        const tree = generateWebpageTree(pages as any);
+        expect(tree).toMatchSnapshot();
+    });
+    it('basic path', () => {
+        const pages = [
+            {
+                url: "https://www.cisa.gov/a/b/c"
+            }
+        ];
+        const tree = generateWebpageTree(pages as any);
+        expect(tree).toMatchSnapshot();
+    });
+    it('single path', () => {
+        const pages = [
+            {
+                url: "https://www.cisa.gov/a"
+            }
+        ];
+        const tree = generateWebpageTree(pages as any);
+        expect(tree).toMatchSnapshot();
+    });
+    it('trailing slash', () => {
+        const pages = [
+            {
+                url: "https://www.cisa.gov/a/"
+            }
+        ];
+        const tree = generateWebpageTree(pages as any);
+        expect(tree).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
Fixes #729 by fixing the logic in `generateWebpageList`. Also added tests for `generateWebpageTree`.

![image](https://user-images.githubusercontent.com/1689183/96600760-49bb5780-12bf-11eb-887a-3ad698f1d92a.png)
