### PR TITLE
Use term vector for webpage_body

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -84,7 +84,7 @@ jobs:
         working-directory: ./
       - name: Sync database
         run: npm run syncdb
-        working-directory: ./
+        working-directory: ./backend
       - name: Test
         run: npm run test -- --collectCoverage
   test_python:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -83,7 +83,7 @@ jobs:
           wait-port -t 3000 5432 9200 9300
         working-directory: ./
       - name: Sync database
-        run: docker-compose exec -T backend npx sls invoke local -f syncdb -d dangerouslyforce
+        run: npm run syncdb
         working-directory: ./
       - name: Test
         run: npm run test -- --collectCoverage

--- a/backend/package.json
+++ b/backend/package.json
@@ -75,7 +75,7 @@
     "build-worker": "./tools/build-worker.sh",
     "deploy-worker-staging": "./tools/deploy-worker.sh",
     "deploy-worker-prod": "./tools/deploy-worker.sh crossfeed-prod-worker",
-    "syncdb": "docker-compose exec backend npx sls invoke local -f syncdb"
+    "syncdb": "ts-node src/tools/run-syncdb.ts dangerouslyforce"
   },
   "author": "",
   "license": "ISC"

--- a/backend/package.json
+++ b/backend/package.json
@@ -75,7 +75,7 @@
     "build-worker": "./tools/build-worker.sh",
     "deploy-worker-staging": "./tools/deploy-worker.sh",
     "deploy-worker-prod": "./tools/deploy-worker.sh crossfeed-prod-worker",
-    "syncdb": "ts-node src/tools/run-syncdb.ts dangerouslyforce"
+    "syncdb": "ts-node src/tools/run-syncdb.ts"
   },
   "author": "",
   "license": "ISC"

--- a/backend/src/tasks/es-client.ts
+++ b/backend/src/tasks/es-client.ts
@@ -51,6 +51,10 @@ class ESClient {
       vulnerabilities: {
         type: 'nested'
       },
+      webpage_body: {
+        type: 'text',
+        term_vector: 'yes'
+      },
       parent_join: {
         type: 'join',
         relations: {

--- a/backend/src/tools/run-syncdb.ts
+++ b/backend/src/tools/run-syncdb.ts
@@ -1,0 +1,20 @@
+import { handler as syncdb } from '../tasks/syncdb';
+
+/**
+ * Runs syncdb locally. This script is called from running "npm run syncdb".
+ * Call "npm run syncdb -- -d dangerouslyforce" to force dropping and
+ * recreating the SQL database.
+ * */
+
+process.env.DB_HOST = 'localhost';
+process.env.DB_USERNAME = 'crossfeed';
+process.env.DB_PASSWORD = 'password';
+process.env.ELASTICSEARCH_ENDPOINT = 'http://localhost:9200';
+
+syncdb(
+  process.argv[3] === '-d' && process.argv[4] === 'dangerouslyforce'
+    ? 'dangerouslyforce'
+    : '',
+  {} as any,
+  () => null
+);


### PR DESCRIPTION
- Use term vector for webpage_body, fixes #782
- Run syncdb faster (without using docker-compose -- using ts-node instead)