### PR TITLE
Fixes clear on searching twice

### DIFF
--- a/frontend/src/components/ColumnFilter/ColumnFilter.tsx
+++ b/frontend/src/components/ColumnFilter/ColumnFilter.tsx
@@ -1,17 +1,17 @@
-import React, { useState } from "react";
-import { TextInput } from "@trussworks/react-uswds";
-import { ColumnInstance } from "react-table";
-import { FaTimes } from "react-icons/fa";
-import classes from "./styles.module.scss";
+import React, { useState } from 'react';
+import { TextInput } from '@trussworks/react-uswds';
+import { ColumnInstance } from 'react-table';
+import { FaTimes } from 'react-icons/fa';
+import classes from './styles.module.scss';
 
 interface Props {
   column: ColumnInstance;
 }
 
 export const ColumnFilter: React.FC<Props> = ({
-  column: { filterValue, setFilter, id },
+  column: { filterValue, setFilter, id }
 }) => {
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
 
   const onSubmit: React.FormEventHandler = (e) => {
     e.preventDefault();
@@ -19,8 +19,8 @@ export const ColumnFilter: React.FC<Props> = ({
   };
 
   const clear: React.MouseEventHandler = (e) => {
-    setSearch("");
-    setFilter("");
+    setSearch('');
+    setFilter('');
   };
 
   return (
@@ -35,7 +35,7 @@ export const ColumnFilter: React.FC<Props> = ({
         }}
       />
       {filterValue && (
-        <button className={classes.clearFilter} onClick={clear}>
+        <button type="button" className={classes.clearFilter} onClick={clear}>
           <FaTimes />
         </button>
       )}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->
Fixes bug where pushing enter twice on a table filter results in clearing the filter.
## 🗣 Description

<!--- Describe your changes in detail -->
Adds type to clear button 

## 💭 Motivation and Context
Issue #801 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
