### PR TITLE
CVEs - Change two-day threshold to one week

### DIFF
--- a/backend/src/tasks/cve.ts
+++ b/backend/src/tasks/cve.ts
@@ -229,8 +229,8 @@ const populateVulnerabilities = async () => {
 
 // Closes or reopens vulnerabilities that need to be updated
 const adjustVulnerabilities = async (type: 'open' | 'closed') => {
-  const twoWeeksAgo = new Date(
-    new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 14)
+  const oneWeekAgo = new Date(
+    new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 7)
   );
   const where: {
     state: string;
@@ -238,7 +238,7 @@ const adjustVulnerabilities = async (type: 'open' | 'closed') => {
     substate?: string;
   } = {
     state: type,
-    lastSeen: type === 'open' ? LessThan(twoWeeksAgo) : MoreThan(twoWeeksAgo)
+    lastSeen: type === 'open' ? LessThan(oneWeekAgo) : MoreThan(oneWeekAgo)
   };
   // If vulnerability is already closed, we should only reopen if it was remediated
   if (type === 'closed') {

--- a/backend/src/tasks/cve.ts
+++ b/backend/src/tasks/cve.ts
@@ -229,8 +229,8 @@ const populateVulnerabilities = async () => {
 
 // Closes or reopens vulnerabilities that need to be updated
 const adjustVulnerabilities = async (type: 'open' | 'closed') => {
-  const twoDaysAgo = new Date(
-    new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 2)
+  const twoWeeksAgo = new Date(
+    new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 14)
   );
   const where: {
     state: string;
@@ -238,7 +238,7 @@ const adjustVulnerabilities = async (type: 'open' | 'closed') => {
     substate?: string;
   } = {
     state: type,
-    lastSeen: type === 'open' ? LessThan(twoDaysAgo) : MoreThan(twoDaysAgo)
+    lastSeen: type === 'open' ? LessThan(twoWeeksAgo) : MoreThan(twoWeeksAgo)
   };
   // If vulnerability is already closed, we should only reopen if it was remediated
   if (type === 'closed') {

--- a/backend/src/tasks/test/cve.test.ts
+++ b/backend/src/tasks/test/cve.test.ts
@@ -159,7 +159,7 @@ describe('cve', () => {
       domain,
       cve: 'CVE-123',
       lastSeen: new Date(
-        new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 7)
+        new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 10)
       ),
       title: '123',
       description: '123'


### PR DESCRIPTION
2 days is too short and sometimes causes us to accidentally close vulnerabilities that should actually be open.