### PR TITLE
Upgrade postgres

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -17,7 +17,7 @@ resource "aws_db_instance" "db" {
   max_allocated_storage   = 1000
   storage_type            = "gp2"
   engine                  = "postgres"
-  engine_version          = "11.5" #change to fit desired PostgresQL version
+  engine_version          = "11.8" #change to fit desired PostgresQL version
   skip_final_snapshot     = true
   availability_zone       = data.aws_availability_zones.available.names[0]
   multi_az                = false


### PR DESCRIPTION
Otherwise, CI gets an error, "Cannot upgrade postgres from 11.8 to 11.5". See https://github.com/cisagov/crossfeed/pull/818/checks?check_run_id=1333557652

Not sure how this was automatically upgraded, though...