### PR TITLE
Fix failing scans

### DIFF
--- a/backend/src/api/login-gov.ts
+++ b/backend/src/api/login-gov.ts
@@ -7,7 +7,7 @@ const loginGov: any = {
 };
 
 const jwkSet = {
-  keys: [JSON.parse(process.env.LOGIN_GOV_JWT_KEY!)]
+  keys: [JSON.parse(process.env.LOGIN_GOV_JWT_KEY ?? '{}')]
 };
 
 const clientOptions: ClientMetadata = {


### PR DESCRIPTION
Scans were failing due to the `LOGIN_GOV_JWT_KEY` variable not being set. This allows the app not to crash when that is not set.