### PR TITLE
Fix infinite refresh on login screen

### DIFF
--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -40,7 +40,7 @@ export const AuthContextProvider: React.FC = ({ children }) => {
       // (i.e. it is now invalid / has expired now).
       window.location.reload();
     }
-  }, [cookies]);
+  }, [cookies, token]);
 
   const handleError = useCallback(
     async (e: Error) => {

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -27,12 +27,19 @@ export const AuthContextProvider: React.FC = ({ children }) => {
   const cookies = useMemo(() => new Cookies(), []);
 
   const logout = useCallback(async () => {
+    const shouldReload = !!token;
+
     localStorage.clear();
     await Auth.signOut();
     cookies.remove('crossfeed-token', {
       domain: process.env.REACT_APP_COOKIE_DOMAIN
     });
-    window.location.reload();
+
+    if (shouldReload) {
+      // Refresh the page only if the token was previously defined
+      // (i.e. it is now invalid / has expired now).
+      window.location.reload();
+    }
   }, [cookies]);
 
   const handleError = useCallback(


### PR DESCRIPTION
Fix infinite refresh on login screen by refreshing the page only when a token was defined previously.