### PR TITLE
Fix CI build by reverting dependabot bump

### DIFF
--- a/backend/worker/requirements.txt
+++ b/backend/worker/requirements.txt
@@ -1,6 +1,6 @@
 requests-http-signature==0.2.0
 requests==2.24.0
 mitmproxy==5.2
-cryptography==3.2
+cryptography==2.9
 pytest==6.0.1
 scrapy==2.3.0


### PR DESCRIPTION
cryptography should be pinned to 2.9, as our version of mitmproxy doesn't work with versions > 3.0.