### PR TITLE
Pin node version in docs dockerfile to fix build errors

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -10,8 +10,7 @@ RUN npm ci
 
 # Generate swagger definitions
 COPY ./backend ../backend
-RUN npm run codegen
-
 COPY ./docs .
+RUN npm run codegen
 
 CMD [ "npm", "run", "develop", "--", "-H", "0.0.0.0", "--port", "4000"]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,7 +1,7 @@
 # This file is built with Docker context in the main directory (not ./docs)
 # so that ./backend is accessible.
 
-FROM node:latest
+FROM node:14-buster-slim
 
 WORKDIR /app/docs
 COPY ./docs/package* ./


### PR DESCRIPTION
Fixes #892 by pinning the node version in the docs Dockerfile.

Also fix the order of build statements; otherwise the generated API swagger file was being overwritten and thus not allowing the docs site to build.