### PR TITLE
Make webscraper bucket deletable

### DIFF
--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -282,6 +282,7 @@ resource "aws_ssm_parameter" "webscraper_s3_bucket_name" {
 resource "aws_s3_bucket" "webscraper_bucket" {
   bucket = var.webscraper_bucket_name
   acl    = "private"
+  force_destroy = true # TODO: delete this bucket
 
   server_side_encryption_configuration {
     rule {

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -280,8 +280,8 @@ resource "aws_ssm_parameter" "webscraper_s3_bucket_name" {
 }
 
 resource "aws_s3_bucket" "webscraper_bucket" {
-  bucket = var.webscraper_bucket_name
-  acl    = "private"
+  bucket        = var.webscraper_bucket_name
+  acl           = "private"
   force_destroy = true # TODO: delete this bucket
 
   server_side_encryption_configuration {


### PR DESCRIPTION
Make webscraper bucket deletable by setting force_destroy equal to True. Once we deploy to prod once, then we can delete the bucket from Terraform and it should properly delete both the bucket and all its contents.