### PR TITLE
Fix flaky webscraper tests by sorting results

### DIFF
--- a/backend/src/tasks/test/__snapshots__/webscraper.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/webscraper.test.ts.snap
@@ -25,15 +25,15 @@ Array [
 
 exports[`webscraper basic test 3`] = `
 Array [
-  "https://docs.crossfeed.cyber.dhs.gov/scans/",
-  "https://docs.crossfeed.cyber.dhs.gov/contributing/",
-  "https://docs.crossfeed.cyber.dhs.gov/usage/",
-  "https://docs.crossfeed.cyber.dhs.gov",
-  "https://docs.crossfeed.cyber.dhs.gov/contributing/deployment/",
-  "https://docs.crossfeed.cyber.dhs.gov/contributing/architecture/",
   "https://docs.crossfeed.cyber.dhs.gov/usage/customization/",
   "https://docs.crossfeed.cyber.dhs.gov/usage/administration/",
+  "https://docs.crossfeed.cyber.dhs.gov/usage/",
+  "https://docs.crossfeed.cyber.dhs.gov/scans/",
   "https://docs.crossfeed.cyber.dhs.gov/contributing/setup/",
+  "https://docs.crossfeed.cyber.dhs.gov/contributing/deployment/",
+  "https://docs.crossfeed.cyber.dhs.gov/contributing/architecture/",
+  "https://docs.crossfeed.cyber.dhs.gov/contributing/",
+  "https://docs.crossfeed.cyber.dhs.gov",
 ]
 `;
 
@@ -43,11 +43,11 @@ Array [
   "200",
   "200",
   "200",
-  "200",
-  "200",
-  "200",
-  "200",
   "400",
+  "200",
+  "200",
+  "200",
+  "200",
 ]
 `;
 

--- a/backend/src/tasks/test/webscraper.test.ts
+++ b/backend/src/tasks/test/webscraper.test.ts
@@ -82,7 +82,10 @@ describe('webscraper', () => {
     });
     const webpages = await Webpage.find({
       where: { domain },
-      relations: ['discoveredBy']
+      relations: ['discoveredBy'],
+      order: {
+        url: 'DESC'
+      },
     });
     expect(
       (spawn as jest.Mock).mock.calls.map((e) => [e[0], e[1]])

--- a/backend/src/tasks/test/webscraper.test.ts
+++ b/backend/src/tasks/test/webscraper.test.ts
@@ -85,7 +85,7 @@ describe('webscraper', () => {
       relations: ['discoveredBy'],
       order: {
         url: 'DESC'
-      },
+      }
     });
     expect(
       (spawn as jest.Mock).mock.calls.map((e) => [e[0], e[1]])


### PR DESCRIPTION
Fix flaky webscraper tests by sorting webscraper results. This test has been intermittently failing in recent CI runs.