### PR TITLE
Add tag support for domain search / export

### DIFF
--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -77,7 +77,7 @@ class DomainSearch {
   // If set to -1, returns all results.
   pageSize?: number;
 
-  async filterResultQueryset(qs: SelectQueryBuilder<Domain>) {
+  async filterResultQueryset(qs: SelectQueryBuilder<Domain>, event) {
     if (this.filters?.reverseName) {
       qs.andWhere('domain.name ILIKE :name', {
         name: `%${this.filters?.reverseName}%`
@@ -141,7 +141,7 @@ class DomainSearch {
       });
     }
 
-    await this.filterResultQueryset(qs);
+    await this.filterResultQueryset(qs, event);
     return await qs.getMany();
   }
 

--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -13,7 +13,11 @@ import { Type } from 'class-transformer';
 import { Domain, connectToDatabase } from '../models';
 import { validateBody, wrapHandler, NotFound } from './helpers';
 import { SelectQueryBuilder, In } from 'typeorm';
-import { isGlobalViewAdmin, getOrgMemberships, getTagOrganizations } from './auth';
+import {
+  isGlobalViewAdmin,
+  getOrgMemberships,
+  getTagOrganizations
+} from './auth';
 import S3Client from '../tasks/s3-client';
 import * as Papa from 'papaparse';
 

--- a/backend/test/domains.test.ts
+++ b/backend/test/domains.test.ts
@@ -4,7 +4,8 @@ import {
   Domain,
   connectToDatabase,
   Organization,
-  Webpage, OrganizationTag
+  Webpage,
+  OrganizationTag
 } from '../src/models';
 import { createUserToken } from './util';
 jest.mock('../src/tasks/s3-client');

--- a/backend/test/domains.test.ts
+++ b/backend/test/domains.test.ts
@@ -4,7 +4,7 @@ import {
   Domain,
   connectToDatabase,
   Organization,
-  Webpage
+  Webpage, OrganizationTag
 } from '../src/models';
 import { createUserToken } from './util';
 jest.mock('../src/tasks/s3-client');
@@ -132,6 +132,41 @@ describe('domains', () => {
         )
         .send({
           filters: { organization: organization.id }
+        })
+        .expect(200);
+      expect(response.body.count).toEqual(1);
+      expect(response.body.result[0].id).toEqual(domain.id);
+    });
+    it('list by globalView with tag filter should only return domains from orgs with that tag', async () => {
+      const tag = await OrganizationTag.create({
+        name: 'test-' + Math.random()
+      });
+      const organization = await Organization.create({
+        name: 'test-' + Math.random(),
+        rootDomains: ['test-' + Math.random()],
+        ipBlocks: [],
+        isPassive: false,
+        tags: [tag]
+      }).save();
+      const name = 'test-' + Math.random();
+      const domain = await Domain.create({
+        name,
+        organization
+      }).save();
+      await Domain.create({
+        name: name + '-2',
+        organization: organization2
+      }).save();
+      const response = await request(app)
+        .post('/domain/search')
+        .set(
+          'Authorization',
+          createUserToken({
+            userType: 'globalView'
+          })
+        )
+        .send({
+          filters: { tag: tag.id }
         })
         .expect(200);
       expect(response.body.count).toEqual(1);

--- a/backend/test/vulnerabilities.test.ts
+++ b/backend/test/vulnerabilities.test.ts
@@ -5,7 +5,7 @@ import {
   Domain,
   connectToDatabase,
   Organization,
-  Vulnerability
+  Vulnerability, OrganizationTag
 } from '../src/models';
 import { createUserToken } from './util';
 jest.mock('../src/tasks/s3-client');
@@ -188,6 +188,55 @@ describe('vulnerabilities', () => {
         )
         .send({
           filters: { organization: organization.id }
+        })
+        .expect(200);
+      expect(response.body.count).toEqual(10000);
+      expect(response.body.result[0].id).toEqual(vulnerability.id);
+    });
+    it('list by globalView with tag filter should work', async () => {
+      const tag = await OrganizationTag.create({
+        name: 'test-' + Math.random()
+      });
+      const organization = await Organization.create({
+        name: 'test-' + Math.random(),
+        rootDomains: ['test-' + Math.random()],
+        ipBlocks: [],
+        isPassive: false,
+        tags: [tag]
+      }).save();
+      const organization2 = await Organization.create({
+        name: 'test-' + Math.random(),
+        rootDomains: ['test-' + Math.random()],
+        ipBlocks: [],
+        isPassive: false
+      }).save();
+      const domain = await Domain.create({
+        name: 'test-' + Math.random(),
+        organization
+      }).save();
+      const title = 'test-' + Math.random();
+      const vulnerability = await Vulnerability.create({
+        title: title + '-1',
+        domain
+      }).save();
+      const domain2 = await Domain.create({
+        name: 'test-' + Math.random(),
+        organization: organization2
+      }).save();
+      const vulnerability2 = await Vulnerability.create({
+        title: title + '-2',
+        domain: domain2
+      }).save();
+      const response = await request(app)
+        .post('/vulnerabilities/search')
+        .set(
+          'Authorization',
+          createUserToken({
+            userType: 'globalView'
+          })
+        )
+        .send({
+          filters: { tag: tag.id }
         })
         .expect(200);
       expect(response.body.count).toEqual(10000);

--- a/backend/test/vulnerabilities.test.ts
+++ b/backend/test/vulnerabilities.test.ts
@@ -5,7 +5,8 @@ import {
   Domain,
   connectToDatabase,
   Organization,
-  Vulnerability, OrganizationTag
+  Vulnerability,
+  OrganizationTag
 } from '../src/models';
 import { createUserToken } from './util';
 jest.mock('../src/tasks/s3-client');


### PR DESCRIPTION
Add tag support for domain search / export endpoints. This way, we can specify `tag: "[tagId]"` when calling these endpoints.

We already have tag support for the vulnerability search / export endpoints. This PR also adds tests for the existing vulnerability functionality.