### PR TITLE
Change andHaving to andWhere for consistency

### DIFF
--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -145,7 +145,7 @@ class DomainSearch {
     return await qs.getMany();
   }
 
-  filterCountQueryset(qs: SelectQueryBuilder<Domain>) {
+  async filterCountQueryset(qs: SelectQueryBuilder<Domain>, event) {
     if (this.filters?.reverseName) {
       qs.andWhere('domain.name ILIKE :name', {
         name: `%${this.filters?.reverseName}%`
@@ -169,6 +169,11 @@ class DomainSearch {
         org: this.filters.organization
       });
     }
+    if (this.filters?.tag) {
+      qs.andWhere('domain."organizationId" IN (:...orgs)', {
+        orgs: await getTagOrganizations(event, this.filters.tag)
+      });
+    }
     if (this.filters?.vulnerability) {
       qs.andWhere('vulnerabilities.title ILIKE :title', {
         title: `%${this.filters?.vulnerability}%`
@@ -185,7 +190,7 @@ class DomainSearch {
         orgs: getOrgMemberships(event)
       });
     }
-    this.filterCountQueryset(qs);
+    await this.filterCountQueryset(qs, event);
     return await qs.getCount();
   }
 }

--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -136,7 +136,7 @@ class DomainSearch {
     }
 
     if (!isGlobalViewAdmin(event)) {
-      qs.andHaving('domain."organizationId" IN (:...orgs)', {
+      qs.andWhere('domain."organizationId" IN (:...orgs)', {
         orgs: getOrgMemberships(event)
       });
     }

--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -111,7 +111,7 @@ class DomainSearch {
       );
     }
     if (this.filters?.tag) {
-      qs.andWhere('organization.id IN (:...orgs)', {
+      qs.andWhere('domain."organizationId" IN (:...orgs)', {
         orgs: await getTagOrganizations(event, this.filters.tag)
       });
     }

--- a/backend/src/api/domains.ts
+++ b/backend/src/api/domains.ts
@@ -102,6 +102,11 @@ class DomainSearch {
         org: this.filters.organization
       });
     }
+    if (this.filters?.tag) {
+      qs.andWhere('domain."organizationId" IN (:...orgs)', {
+        orgs: await getTagOrganizations(event, this.filters.tag)
+      });
+    }
     if (this.filters?.vulnerability) {
       qs.andHaving(
         'COUNT(CASE WHEN vulnerabilities.title ILIKE :title THEN 1 END) >= 1',
@@ -109,11 +114,6 @@ class DomainSearch {
           title: `%${this.filters?.vulnerability}%`
         }
       );
-    }
-    if (this.filters?.tag) {
-      qs.andWhere('domain."organizationId" IN (:...orgs)', {
-        orgs: await getTagOrganizations(event, this.filters.tag)
-      });
     }
     return qs;
   }

--- a/backend/test/domains.test.ts
+++ b/backend/test/domains.test.ts
@@ -141,7 +141,7 @@ describe('domains', () => {
     it('list by globalView with tag filter should only return domains from orgs with that tag', async () => {
       const tag = await OrganizationTag.create({
         name: 'test-' + Math.random()
-      });
+      }).save();
       const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],

--- a/backend/test/vulnerabilities.test.ts
+++ b/backend/test/vulnerabilities.test.ts
@@ -197,7 +197,7 @@ describe('vulnerabilities', () => {
     it('list by globalView with tag filter should work', async () => {
       const tag = await OrganizationTag.create({
         name: 'test-' + Math.random()
-      });
+      }).save();
       const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],


### PR DESCRIPTION
Change andHaving to andWhere for consistency -- we use andWhere elsewhere in the code (`getCount`) to filter results to the user's own accessible organizations. I believe in this case, either will have the same effect.