### PR TITLE
Fix count queries for domains / scantasks / vulnerabilities

### DIFF
--- a/backend/src/api/scan-tasks.ts
+++ b/backend/src/api/scan-tasks.ts
@@ -68,20 +68,7 @@ class ScanTaskSearch {
       .take(PAGE_SIZE);
 
     this.filterResultQueryset(qs);
-    return await qs.getMany();
-  }
-
-  filterCountQueryset(qs: SelectQueryBuilder<ScanTask>) {
-    return this.filterResultQueryset(qs);
-  }
-
-  async getCount(event) {
-    const qs = ScanTask.createQueryBuilder('scan_task').leftJoinAndSelect(
-      'scan_task.scan',
-      'scan'
-    );
-    this.filterCountQueryset(qs);
-    return await qs.getCount();
+    return qs.getManyAndCount();
   }
 }
 
@@ -100,10 +87,7 @@ export const list = wrapHandler(async (event) => {
   }
   await connectToDatabase();
   const search = await validateBody(ScanTaskSearch, event.body);
-  const [result, count] = await Promise.all([
-    search.getResults(event),
-    search.getCount(event)
-  ]);
+  const [result, count] = await search.getResults(event);
   return {
     statusCode: 200,
     body: JSON.stringify({

--- a/backend/src/api/vulnerabilities.ts
+++ b/backend/src/api/vulnerabilities.ts
@@ -168,7 +168,7 @@ class VulnerabilitySearch {
         orgs: getOrgMemberships(event)
       });
     }
-    return [await qs.getMany(), 10000];
+    return qs.getManyAndCount();
   }
 }
 

--- a/backend/test/vulnerabilities.test.ts
+++ b/backend/test/vulnerabilities.test.ts
@@ -102,7 +102,7 @@ describe('vulnerabilities', () => {
         )
         .send({})
         .expect(200);
-      expect(response.body.count).toEqual(10000);
+      expect(response.body.count).toEqual(1);
       expect(response.body.result[0].id).toEqual(vulnerability.id);
     });
     it('list by globalView should return vulnerabilities from all orgs', async () => {
@@ -147,7 +147,7 @@ describe('vulnerabilities', () => {
           filters: { title }
         })
         .expect(200);
-      expect(response.body.count).toEqual(10000);
+      expect(response.body.count).toEqual(2);
     });
     it('list by globalView with org filter should work', async () => {
       const organization = await Organization.create({
@@ -191,7 +191,7 @@ describe('vulnerabilities', () => {
           filters: { organization: organization.id }
         })
         .expect(200);
-      expect(response.body.count).toEqual(10000);
+      expect(response.body.count).toEqual(1);
       expect(response.body.result[0].id).toEqual(vulnerability.id);
     });
     it('list by globalView with tag filter should work', async () => {
@@ -240,7 +240,7 @@ describe('vulnerabilities', () => {
           filters: { tag: tag.id }
         })
         .expect(200);
-      expect(response.body.count).toEqual(10000);
+      expect(response.body.count).toEqual(1);
       expect(response.body.result[0].id).toEqual(vulnerability.id);
     });
     it('list by org user with custom pageSize should work', async () => {
@@ -274,7 +274,7 @@ describe('vulnerabilities', () => {
           pageSize: 1
         })
         .expect(200);
-      expect(response.body.count).toEqual(10000);
+      expect(response.body.count).toEqual(2);
       expect(response.body.result.length).toEqual(1);
     });
     it('list by org user with pageSize of -1 should return all results', async () => {
@@ -308,7 +308,7 @@ describe('vulnerabilities', () => {
           pageSize: -1
         })
         .expect(200);
-      expect(response.body.count).toEqual(10000);
+      expect(response.body.count).toEqual(2);
       expect(response.body.result.length).toEqual(2);
     });
   });


### PR DESCRIPTION
- Fix count queries for vulnerabilities by not hardcoding the count to 10000. This would cause issues where the vulnerabilities page would always show "10000 results", even if there were less:

![image](https://user-images.githubusercontent.com/1689183/107173723-81492f00-6996-11eb-8a9d-463f2e287b42.png)


- Improve count queries for scantasks / domains by using the `getManyAndCount()` function, instead of duplicating the same query task using both `getMany()` and `getCount()`