### PR TITLE
Revert "disable security pipeline check for now"

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -125,7 +125,7 @@ jobs:
         run: npm run build-worker
         working-directory: ./backend
   deploy:
-    needs: [build_worker, lint, test, test_python]
+    needs: [security, build_worker, lint, test, test_python]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/production')
     steps:


### PR DESCRIPTION
This reverts commit e91e0c1841da3b804198517c4b3729ffb7aa4c56.

As the axios version bump (#899) has now been merged, we can now re-add the security checks to the backend GHA pipeline. Fixes #936.