### PR TITLE
Increase jwt expiration time to 3 days

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -160,7 +160,7 @@ export const callback = async (event, context) => {
   }
 
   const token = jwt.sign(userTokenBody(user), process.env.JWT_SECRET!, {
-    expiresIn: '1 day',
+    expiresIn: '3 days',
     header: {
       typ: 'JWT'
     }


### PR DESCRIPTION
Increase jwt expiration time to 3 days, as 1 day makes it really inconvenient to have to login / enter 2FA codes every single day. We should later implement a "Keep me signed in" and/or refresh token mechanism so this option can be more flexible and configurable.