### PR TITLE
Fix MultiSelect overflow height

### DIFF
--- a/frontend/src/pages/Scans/MultiSelect.tsx
+++ b/frontend/src/pages/Scans/MultiSelect.tsx
@@ -35,8 +35,8 @@ export default (
           borderColor: '#565c65',
           borderWidth: 1,
           marginTop: '0.5rem',
-          height: '2.5rem',
-          borderRadius: 0
+          minHeight: '2.5rem',
+          borderRadius: 0,
         })
       }}
     />


### PR DESCRIPTION
Fixes #847, making it easier to associate a scan with a large number of organizations.

The MultiSelect now overflows properly:

![image](https://user-images.githubusercontent.com/1689183/107174558-87d8a600-6998-11eb-95e8-7da878c6c527.png)
