### PR TITLE
Fix Cancel button for Organization page

### DIFF
--- a/frontend/src/pages/Organization/Organization.tsx
+++ b/frontend/src/pages/Organization/Organization.tsx
@@ -599,13 +599,14 @@ export const Organization: React.FC = () => {
         </span>
       </div>
       <div className={classes.buttons}>
-        <Button
-          variant="outlined"
-          style={{ marginRight: '10px', color: '#565C65' }}
-          onClick={fetchOrganization}
-        >
-          Cancel
-        </Button>
+        <Link to={`/organizations`}>
+          <Button
+            variant="outlined"
+            style={{ marginRight: '10px', color: '#565C65' }}
+          >
+            Cancel
+          </Button>
+        </Link>
         <Button
           variant="contained"
           onClick={updateOrganization}


### PR DESCRIPTION
Fixes #935. Now, clicking on the "Cancel" button from an Organization detail page will properly go back to the organization list page (`/organizations`).

![image](https://user-images.githubusercontent.com/1689183/107174801-2533da00-6999-11eb-9787-1d9e86d67a8b.png)
