### PR TITLE
Fix issue with global scans not running

### DIFF
--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -15,6 +15,7 @@ import { handler as cve } from './tasks/cve';
 import { handler as webscraper } from './tasks/webscraper';
 import { handler as shodan } from './tasks/shodan';
 import { handler as testProxy } from './tasks/test-proxy';
+import { SCAN_SCHEMA } from './api/scans';
 
 /**
  * Worker entrypoint.
@@ -26,6 +27,8 @@ async function main() {
   console.log('commandOptions are', commandOptions);
 
   const { scanName, organizations = [] } = commandOptions;
+
+  const { global } = SCAN_SCHEMA[scanName];
 
   const scanFn = {
     amass,
@@ -54,16 +57,21 @@ async function main() {
     bootstrap();
   }
 
-  // Since a single ScanTask can correspond to multiple organizations,
-  // we run scanFn for each particular organization here by passing
-  // in the current organization's name and id into commandOptions.
-  for (const organization of organizations) {
-    await scanFn({
-      ...commandOptions,
-      organizations: [],
-      organizationId: organization.id,
-      organizationName: organization.name
-    });
+  if (global) {
+    await scanFn(commandOptions);
+  } else {
+    // For non-global scans, since a single ScanTask can correspond to
+    // multiple organizations, we run scanFn for each particular
+    // organization here by passing in the current organization's
+    // name and id into commandOptions.
+    for (const organization of organizations) {
+      await scanFn({
+        ...commandOptions,
+        organizations: [],
+        organizationId: organization.id,
+        organizationName: organization.name
+      });
+    }
   }
 }
 

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -28,8 +28,6 @@ async function main() {
 
   const { scanName, organizations = [] } = commandOptions;
 
-  const { global } = SCAN_SCHEMA[scanName];
-
   const scanFn = {
     amass,
     censys,
@@ -56,6 +54,8 @@ async function main() {
   } else {
     bootstrap();
   }
+
+  const { global } = SCAN_SCHEMA[scanName];
 
   if (global) {
     await scanFn(commandOptions);


### PR DESCRIPTION
Fix an issue with global scans not running that was introduced by #920. Because the new logic introduced would loop through all selected organizations to run the worker scan code, this would end up not running the scan code at all for global scans (which have the `.organizations` property set to an empty array).