### PR TITLE
Fix bug where shodan mismatches CPEs

### DIFF
--- a/backend/src/tasks/shodan.ts
+++ b/backend/src/tasks/shodan.ts
@@ -106,29 +106,30 @@ export const handler = async (commandOptions: CommandOptions) => {
               })
             ]);
             if (service.vulns) {
-              console.log('creating vulnerability');
-              const vulns: Vulnerability[] = [];
-              for (const cve in service.vulns) {
-                vulns.push(
-                  plainToClass(Vulnerability, {
-                    domain: domain,
-                    lastSeen: new Date(Date.now()),
-                    title: cve,
-                    cve: cve,
-                    cpe:
-                      service.cpe && service.cpe.length > 0
-                        ? service.cpe[0]
-                        : null,
-                    cvss: service.vulns[cve].cvss,
-                    state: 'open',
-                    source: 'shodan',
-                    description: service.vulns[cve].summary,
-                    needsPopulation: true,
-                    service: { id: serviceId }
-                  })
-                );
-              }
-              await saveVulnerabilitiesToDb(vulns, false);
+              // Don't create vulns from shodan now -- too many false positives.
+              // console.log('creating vulnerability');
+              // const vulns: Vulnerability[] = [];
+              // for (const cve in service.vulns) {
+              //   vulns.push(
+              //     plainToClass(Vulnerability, {
+              //       domain: domain,
+              //       lastSeen: new Date(Date.now()),
+              //       title: cve,
+              //       cve: cve,
+              //       cpe:
+              //         service.cpe && service.cpe.length > 0
+              //           ? service.cpe[0]
+              //           : null,
+              //       cvss: service.vulns[cve].cvss,
+              //       state: 'open',
+              //       source: 'shodan',
+              //       description: service.vulns[cve].summary,
+              //       needsPopulation: true,
+              //       service: { id: serviceId }
+              //     })
+              //   );
+              // }
+              // await saveVulnerabilitiesToDb(vulns, false);
             }
           }
         }

--- a/backend/src/tasks/test/__snapshots__/shodan.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/shodan.test.ts.snap
@@ -33,16 +33,24 @@ A003 BAD Error in IMAP command received by server.
         "port": 993,
         "products": Array [
           Object {
-            "cpe": "1234",
-            "name": "Test",
+            "cpe": "cpe:/a:igor_sysoev:nginx:1.18.0",
+            "name": "nginx",
             "tags": Array [],
-            "version": "1.1",
+            "vendor": "igor sysoev",
+            "version": "1.18.0",
+          },
+          Object {
+            "cpe": "cpe:/a:atlassian:confluence",
+            "name": "confluence",
+            "tags": Array [],
+            "vendor": "atlassian",
           },
         ],
         "service": null,
         "shodanResults": Object {
           "cpe": Array [
-            "1234",
+            "cpe:/a:igor_sysoev:nginx:1.18.0",
+            "cpe:/a:atlassian:confluence",
           ],
           "product": "Test",
           "version": "1.1",

--- a/backend/src/tasks/test/shodan.test.ts
+++ b/backend/src/tasks/test/shodan.test.ts
@@ -227,7 +227,7 @@ describe('shodan', () => {
     });
     await checkDomains(organization);
   });
-  test('creates vulnerability', async () => {
+  test.skip('creates vulnerability', async () => {
     nock('https://api.shodan.io')
       .get(
         `/shodan/host/153.126.148.60,31.134.10.156,1.1.1.1?key=${process.env.SHODAN_API_KEY}`

--- a/backend/src/tasks/test/shodan.test.ts
+++ b/backend/src/tasks/test/shodan.test.ts
@@ -49,7 +49,7 @@ const shodanResponse = [
         ip_str: '153.126.148.60',
         product: 'Test',
         version: '1.1',
-        cpe: ['1234']
+        cpe: ['cpe:/a:igor_sysoev:nginx:1.18.0', 'cpe:/a:atlassian:confluence']
       }
     ],
     asn: 'AS7684',
@@ -265,15 +265,22 @@ describe('shodan', () => {
     expect(service!.shodanResults).toEqual({
       product: 'Test',
       version: '1.1',
-      cpe: ['1234']
+      cpe: ['cpe:/a:igor_sysoev:nginx:1.18.0', 'cpe:/a:atlassian:confluence']
     });
-    expect(service!.products).toHaveLength(1);
+    expect(service!.products).toHaveLength(2);
     expect(service!.products).toEqual([
       {
-        name: 'Test',
-        version: '1.1',
-        cpe: '1234',
-        tags: []
+        cpe: 'cpe:/a:igor_sysoev:nginx:1.18.0',
+        name: 'nginx',
+        tags: [],
+        vendor: 'igor sysoev',
+        version: '1.18.0'
+      },
+      {
+        cpe: 'cpe:/a:atlassian:confluence',
+        name: 'confluence',
+        tags: [],
+        vendor: 'atlassian'
       }
     ]);
   });


### PR DESCRIPTION
Fixes #951, in which results from shodan would cause multiple CPEs to be saved incorrectly. Now, we just ignore the `product` and `version` keys altogether and just create a new product for each CPE in the `cpes` array.

Also, stop creating vulns from shodan now -- there are too many false positives, and we can't easily determine which CPE caused the particular vuln indicated by shodan.