### PR TITLE
Fix cve scan on CPEs that already contain version numbers

### DIFF
--- a/backend/src/tasks/cve.ts
+++ b/backend/src/tasks/cve.ts
@@ -18,7 +18,20 @@ import * as zlib from 'zlib';
  * The CVE scan creates vulnerabilities based on existing
  * data (such as product version numbers / CPEs, webpages)
  * that have already been collected from other scans.
- */
+ * 
+ * To manually test the CVE tools from your command line, run:
+
+nvdsync -cve_feed cve-1.1.json.gz nvd-dump
+
+cpe2cve -d ' ' -d2 , -o ' ' -o2 , -cpe 2 -e 2 -matches 3 -cve 2 -cvss 4 -cwe 5 -require_version nvd-dump/nvdcve-1.1-2*.json.gz
+
+Then input:
+
+0 cpe:/a:microsoft:exchange_server:2019:cumulative_update_3
+
+Press ctrl + D to end input.
+
+*/
 
 const productMap = {
   'cpe:/a:microsoft:asp.net': ['cpe:/a:microsoft:.net_framework']
@@ -26,6 +39,18 @@ const productMap = {
 
 // The number of domains to process at once
 const BATCH_SIZE = 1000;
+
+/**
+ * Construct a CPE to be added. If the CPE doesn't already contain
+ * the version, then add the version to the CPE.
+ */
+const constructCPE = (cpe, version) => {
+  if (cpe?.indexOf(String(version)) > -1) {
+    // CPE already has the product version. Just add it.
+    return cpe;
+  }
+  return `${cpe}:${version}`;
+};
 
 /**
  * Scan for new vulnerabilities based on version numbers of identified CPEs
@@ -46,10 +71,11 @@ const identifyPassiveCVEsFromCPEs = async (allDomains: Domain[]) => {
           product.version &&
           String(product.version).split('.').length > 1
         ) {
-          cpes.add(product.cpe + ':' + product.version);
+          cpes.add(constructCPE(product.cpe, product.version));
           if (productMap[product.cpe]) {
+            // Add alternate variants of the CPE as well.
             for (const cpe of productMap[product.cpe]) {
-              cpes.add(cpe + ':' + product.version);
+              cpes.add(constructCPE(cpe, product.version));
             }
           }
         }

--- a/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
@@ -50,6 +50,16 @@ Array [
 ]
 `;
 
+exports[`cve product with cpe with version in it: execSync.input 1`] = `
+"0 cpe:/a:10web:form_maker:1.0.0
+"
+`;
+
+exports[`cve product with cpe without version in it: execSync.input 1`] = `
+"0 cpe:/a:10web:form_maker:1.0.0
+"
+`;
+
 exports[`cve simple test: execSync.input 1`] = `
 "0 cpe:/a:10web:form_maker:1.0.0
 "

--- a/backend/src/tasks/test/cve.test.ts
+++ b/backend/src/tasks/test/cve.test.ts
@@ -119,6 +119,91 @@ describe('cve', () => {
       );
     }
   });
+
+  test('product with cpe without version in it', async () => {
+    const organization = await Organization.create({
+      name: 'test-' + Math.random(),
+      rootDomains: ['test-' + Math.random()],
+      ipBlocks: [],
+      isPassive: false
+    }).save();
+    const name = 'test-' + Math.random();
+    const domain = await Domain.create({
+      name,
+      organization
+    }).save();
+    const service = await Service.create({
+      domain,
+      port: 80,
+      wappalyzerResults: [
+        {
+          cpe: 'cpe:/a:10web:form_maker',
+          version: '1.0.0'
+        }
+      ]
+    }).save();
+    await cve({
+      organizationId: organization.id,
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    const vulnerabilities = await Vulnerability.find({
+      where: {
+        domain: domain,
+        service: service
+      }
+    });
+    expect(vulnerabilities.length).toEqual(2);
+    expect(vulnerabilities.map((e) => e.cve).sort()).toEqual([
+      'CVE-2019-10866',
+      'CVE-2019-11590'
+    ]);
+  });
+
+  test('product with cpe with version in it', async () => {
+    const organization = await Organization.create({
+      name: 'test-' + Math.random(),
+      rootDomains: ['test-' + Math.random()],
+      ipBlocks: [],
+      isPassive: false
+    }).save();
+    const name = 'test-' + Math.random();
+    const domain = await Domain.create({
+      name,
+      organization
+    }).save();
+    const service = await Service.create({
+      domain,
+      port: 80,
+      wappalyzerResults: [
+        {
+          cpe: 'cpe:/a:10web:form_maker:1.0.0',
+          version: '1.0.0'
+        }
+      ]
+    }).save();
+    await cve({
+      organizationId: organization.id,
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    const vulnerabilities = await Vulnerability.find({
+      where: {
+        domain: domain,
+        service: service
+      }
+    });
+    expect(vulnerabilities.length).toEqual(2);
+    expect(vulnerabilities.map((e) => e.cve).sort()).toEqual([
+      'CVE-2019-10866',
+      'CVE-2019-11590'
+    ]);
+  });
+
   test('should exit if no matching domains with cpes', async () => {
     const organization = await Organization.create({
       name: 'test-' + Math.random(),


### PR DESCRIPTION
## 🗣 Description ##

Fix cve scan on CPEs that already contain version numbers; fixes #961. This way, the CPEs will be properly input into the `cpe2cve` command-line tool.