### PR TITLE
Make backend tests log less

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -86,7 +86,7 @@ jobs:
         run: npm run syncdb
         working-directory: ./backend
       - name: Test
-        run: npm run test -- --collectCoverage
+        run: npm run test -- --collectCoverage --silent
   test_python:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/backend/src/tasks/test/wappalyzer.test.ts
+++ b/backend/src/tasks/test/wappalyzer.test.ts
@@ -252,7 +252,6 @@ describe('wappalyzer', () => {
     const service2 = await Service.findOne(testServices[1].id);
     expect(service2?.wappalyzerResults).toEqual(wappalyzerResponse);
 
-    console.warn(service2?.products);
     expect(service2?.products).toEqual([
       {
         cpe: 'cpe:/a:microsoft:exchange_server:2019:cumulative_update_5',


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Make backend tests log less. The `--silent` option in jest suppresses all `console.log` output. Otherwise, tests log a lot of output and it's cumbersome to scroll through all the output (see https://github.com/cisagov/crossfeed/runs/2026577665 for an example).