### PR TITLE
Use pm2 to handle worker entrypoint, to fix exiting / hanging issues

### DIFF
--- a/backend/worker/worker-entry.sh
+++ b/backend/worker/worker-entry.sh
@@ -22,7 +22,7 @@ export AWS_CA_BUNDLE=/usr/local/share/ca-certificates/mitmproxy-ca-cert.crt
 # Main code
 echo "Running main code..."
 
-node --unhandled-rejections=strict worker.bundle.js
+pm2-docker --no-daemon --no-autorestart --node-args="--unhandled-rejections=strict" worker.bundle.js
 
 pm2 stop all | grep "^\[PM2\]"
 


### PR DESCRIPTION
## 🗣 Description ##

Use pm2 to handle the worker entrypoint. This should fix exiting / handing issues with scans when the node script throws an error, for example with #967 and #937.