### PR TITLE
Better batch domains in cve scan to meet memory limits

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -118,7 +118,7 @@ export const SCAN_SCHEMA: ScanSchema = {
     isPassive: true,
     global: true,
     cpu: '1024',
-    memory: '4096',
+    memory: '8192',
     description: 'Matches detected software versions to CVEs from NIST NVD'
   },
   searchSync: {

--- a/backend/src/tasks/ecs-client.ts
+++ b/backend/src/tasks/ecs-client.ts
@@ -83,7 +83,8 @@ class ECSClient {
             // In order to use the host name "db" to access the database from the
             // crossfeed-worker image, we must launch the Docker container with
             // the Crossfeed backend network.
-            NetworkMode: 'crossfeed_backend'
+            NetworkMode: 'crossfeed_backend',
+            Memory: 4000000000 // Limit memory to 4 GB. We do this locally to better emulate fargate memory conditions. TODO: In the future, we could read the exact memory from SCAN_SCHEMA to better emulate memory requirements for each scan.
           },
           Env: [
             `CROSSFEED_COMMAND_OPTIONS=${JSON.stringify(commandOptions)}`,

--- a/backend/src/tasks/search-sync.ts
+++ b/backend/src/tasks/search-sync.ts
@@ -8,7 +8,7 @@ import pRetry from 'p-retry';
 /**
  * Chunk sizes. These values are small during testing to facilitate testing.
  */
-export const DOMAIN_CHUNK_SIZE = typeof jest === 'undefined' ? 100 : 10;
+export const DOMAIN_CHUNK_SIZE = typeof jest === 'undefined' ? 50 : 10;
 
 export const handler = async (commandOptions: CommandOptions) => {
   const { organizationId, domainId } = commandOptions;

--- a/backend/src/tasks/wappalyzer.ts
+++ b/backend/src/tasks/wappalyzer.ts
@@ -6,6 +6,7 @@ import { wappalyzer } from './helpers/simple-wappalyzer';
 
 const wappalyze = async (domain: LiveDomain): Promise<void> => {
   try {
+    // domain.url = 'https://autodiscover.cityofpensacola.com';
     const { data, status, headers } = await axios.get(domain.url, {
       validateStatus: () => true
     });


### PR DESCRIPTION
Attempts to address #961 by better batching domains in the cve scans, so that less memory is used. Also increases the memory used for the cve scans in general to 8192 (8 GB).

Finally, adds a 4 GB memory limit for local scans being run through Docker, to better emulate the Fargate memory constraints.