### PR TITLE
Increase cpu and memory for wappalyzer scan

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -79,6 +79,8 @@ export const SCAN_SCHEMA: ScanSchema = {
     type: 'fargate',
     isPassive: true,
     global: false,
+    cpu: '1024',
+    memory: '4096',
     description:
       'Open source tool that fingerprints web technologies based on HTTP responses'
   },


### PR DESCRIPTION
The wappalyzer scan is often failing on prod with the message, "Killed." This PR increases the cpu and memory for that scan so that hopefully it will fail less often.