### PR TITLE
Expand CISA internal users that don't need to sign TOS

### DIFF
--- a/frontend/src/context/userStateUtils.ts
+++ b/frontend/src/context/userStateUtils.ts
@@ -24,7 +24,7 @@ export const getTouVersion = (maxRole: string) => {
 };
 
 export const getUserMustSign = (user: AuthUser | null, touVersion: string) => {
-  const approvedEmailAddresses = ['@cisa.dhs.gov'];
+  const approvedEmailAddresses = ['@cisa.dhs.gov', '@associates.cisa.dhs.gov'];
   for (let email of approvedEmailAddresses) {
     if (user?.email.endsWith(email)) return false;
   }


### PR DESCRIPTION
Expand CISA internal users that don't need to sign TOS to users with email address `@associates.cisa.dhs.gov`.