### PR TITLE
Build docker containers faster, in parallel

### DIFF
--- a/backend/src/tasks/test-proxy.ts
+++ b/backend/src/tasks/test-proxy.ts
@@ -21,7 +21,7 @@ const WEBSCRAPER_DIRECTORY = '/app/worker/webscraper';
  * Crossfeed test user agent.
  *
  * To run the test, run:
- * docker-compose up --build
+ * npm start (from the root directory)
  * cd backend && docker run -e WORKER_TEST=true --network="crossfeed_backend" -t crossfeed-worker
  *
  * In the future, we can point these URLs to a locally running web server

--- a/docs/src/documentation-pages/contributing/setup.md
+++ b/docs/src/documentation-pages/contributing/setup.md
@@ -6,12 +6,15 @@ sidenav: contributing
 ### Quickstart
 
 1.  Copy root `dev.env.example` file to a `.env` file, and change values as desired:
+
     - `cp dev.env.example .env`
 
 1.  Build the crossfeed-worker Docker image:
+
     - `cd backend && npm run build-worker`
 
 1.  Start entire environment from the root directory using Docker Compose:
+
     - `npm start`
 
 1.  Generate DB schema:

--- a/docs/src/documentation-pages/contributing/setup.md
+++ b/docs/src/documentation-pages/contributing/setup.md
@@ -7,10 +7,13 @@ sidenav: contributing
 
 1.  Copy root `dev.env.example` file to a `.env` file, and change values as desired:
     - `cp dev.env.example .env`
-1.  Build the crossfeed-worker Docker image
+
+1.  Build the crossfeed-worker Docker image:
     - `cd backend && npm run build-worker`
-1.  Start entire environment from root using Docker Compose
-    - `docker-compose up --build`
+
+1.  Start entire environment from the root directory using Docker Compose:
+    - `npm start`
+
 1.  Generate DB schema:
 
     - `cd backend && npm run syncdb`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "main": "index.js",
     "scripts": {
-      "start": "docker-compose up --build"
+      "start": "docker-compose build --parallel && docker-compose up --force-recreate"
     },
     "repository": {
       "type": "git",


### PR DESCRIPTION
Build docker containers faster, in parallel, when running locally. Previously, they would just build serially.

Also updated the setup documentation a bit.