### PR TITLE
Scale prod db disk storage to 100 GB

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -13,7 +13,7 @@ resource "aws_db_subnet_group" "default" {
 resource "aws_db_instance" "db" {
   identifier              = var.db_name
   instance_class          = var.db_instance_class
-  allocated_storage       = 20
+  allocated_storage       = 100
   max_allocated_storage   = 1000
   storage_type            = "gp2"
   engine                  = "postgres"


### PR DESCRIPTION
Scale prod db disk storage to 100 GB to fix out-of-disk-space errors with large domain exports.