### PR TITLE
Fix domain pagination issues where number of pages is overestimated

### DIFF
--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -93,9 +93,10 @@ export const Table = <T extends object>(props: TableProps<T>) => {
       fetchData({
         sort: sortBy,
         page: pageIndex + 1,
+        pageSize,
         filters
       });
-  }, [fetchData, sortBy, filters, pageIndex]);
+  }, [fetchData, sortBy, filters, pageIndex, pageSize]);
 
   return (
     <div className={classes.root}>


### PR DESCRIPTION
Fix domain pagination issues where number of pages is overestimated, by ensuring that the right `pageSize` is sent to the backend. Previously, a `pageSize` of 25 was sent to the backend but the frontend estimated page numbers based on a `pageSize` of 15. With this change, a `pageSize` of 15 will be used throughout.

Fixes #1011.