### PR TITLE
Fix Inventory page refresh when org dropdown changes

### DIFF
--- a/backend/src/api/search.ts
+++ b/backend/src/api/search.ts
@@ -88,7 +88,7 @@ const getOptions = async (
     (getOrgMemberships(event).includes(searchBody.organizationId) ||
       isGlobalViewAdmin(event))
   ) {
-    //Search for a specific organization
+    // Search for a specific organization
     options = {
       organizationIds: [searchBody.organizationId],
       matchAllOrganizations: false

--- a/frontend/src/context/SearchProvider/SearchProvider.tsx
+++ b/frontend/src/context/SearchProvider/SearchProvider.tsx
@@ -84,5 +84,7 @@ export const SearchProvider: React.FC = ({ children }) => {
     }
   };
 
-  return <ESProvider config={config}>{children}</ESProvider>;
+  // Use an organization-specific key so that the search results
+  // page properly resets when the current organization is changed.
+  return <ESProvider config={config} key={`es-provider-${currentOrganization?.name}-${showAllOrganizations}`}>{children}</ESProvider>;
 };


### PR DESCRIPTION
Fixes #949.

Gives an organization-specific key to the `ESProvider` component so that the search results page properly resets when the current organization is changed.