### PR TITLE
Include alternate IIS CPEs

### DIFF
--- a/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
@@ -50,7 +50,7 @@ Array [
 ]
 `;
 
-exports[`cve product with IIS cpe: execSync.input 1`] = `
+exports[`cve product with IIS cpe should include alternate cpes defined in productMap: execSync.input 1`] = `
 "0 cpe:/a:microsoft:internet_information_server:7.5,cpe:/a:microsoft:internet_information_services:7.5
 "
 `;

--- a/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
@@ -50,6 +50,11 @@ Array [
 ]
 `;
 
+exports[`cve product with IIS cpe: execSync.input 1`] = `
+"0 cpe:/a:microsoft:internet_information_server:7.5,cpe:/a:microsoft:internet_information_services:7.5
+"
+`;
+
 exports[`cve product with cpe with trailing colon: execSync.input 1`] = `
 "0 cpe:/a:10web:form_maker::1.0.0
 "

--- a/backend/src/tasks/test/cve.test.ts
+++ b/backend/src/tasks/test/cve.test.ts
@@ -330,6 +330,38 @@ describe('cve', () => {
     ]);
   });
 
+  test('product with IIS cpe should include alternate cpes defined in productMap', async () => {
+    const organization = await Organization.create({
+      name: 'test-' + Math.random(),
+      rootDomains: ['test-' + Math.random()],
+      ipBlocks: [],
+      isPassive: false
+    }).save();
+    const name = 'test-' + Math.random();
+    const domain = await Domain.create({
+      name,
+      organization
+    }).save();
+    const service = await Service.create({
+      domain,
+      port: 80,
+      wappalyzerResults: [
+        {
+          technology: {
+            cpe: 'cpe:/a:microsoft:internet_information_server'
+          },
+          version: '7.5'
+        }
+      ]
+    }).save();
+    await cve({
+      organizationId: organization.id,
+      scanId: 'scanId',
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+  });
+
   test('should exit if no matching domains with cpes', async () => {
     const organization = await Organization.create({
       name: 'test-' + Math.random(),


### PR DESCRIPTION
For #961 -- include alternate IIS CPEs. We would receive `cpe:/a:microsoft:internet_information_server` from our data sources, but putting that into NVD gives us no results because the CPE has been renamed to `cpe:/a:microsoft:internet_information_services` instead (which _does_ give us several vulnerabilities as results).