### PR TITLE
Documentation: Generate correct slugs, highlighting

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
         items: [{ text: 'Home', link: '/' }],
       },
       {
-        items: [{ text: 'User Guide', link: '/product-overview' }],
+        items: [{ text: 'User Guide', link: '/usage/product-overview' }],
       },
       {
         items: [{ text: 'Contributing', link: '/contributing' }],

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -5,6 +5,7 @@
  */
 
 const path = require('path');
+const { createFilePath } = require('gatsby-source-filesystem');
 
 // Adds the source "name" from the filesystem plugin to the markdown remark nodes
 // so we can filter by it.
@@ -29,6 +30,17 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
     name: 'name',
     value: fileNode.name,
   });
+
+  const slug = createFilePath({
+    node,
+    getNode,
+    basePath: `src/documentation-pages`,
+  });
+  createNodeField({
+    node,
+    name: 'slug',
+    value: slug,
+  });
 };
 
 exports.createPages = async ({ actions, graphql }) => {
@@ -43,7 +55,7 @@ async function createMarkdownPages(createPage, graphql) {
 
   pages.forEach(({ node }) => {
     createPage({
-      path: node.fields.name,
+      path: node.fields.slug,
       component: pageTemplate,
       context: {
         name: node.fields.name,
@@ -60,6 +72,7 @@ async function markdownQuery(graphql, source) {
           node {
             fields {
               name
+              slug
             }
           }
         }

--- a/docs/src/components/highlights.js
+++ b/docs/src/components/highlights.js
@@ -96,7 +96,7 @@ const Highlights = () => (
         <div className="usa-media-block tablet:grid-col">
           <a
             className="usa-button usa-button--big usa-button--accent-cool"
-            href="/product-overview"
+            href="/usage/product-overview"
             style={{ margin: 'auto', display: 'block' }}
           >
             Get started

--- a/docs/src/components/nav.js
+++ b/docs/src/components/nav.js
@@ -13,7 +13,6 @@ const Nav = ({ navigation, secondaryLinks }) => (
       <ul className="usa-accordion usa-nav__primary">
         {navigation.map((navGroup, idx) => (
           <li key={idx} className="usa-nav__primary-item">
-            {!navGroup.items && console.warn(navGroup)}
             {navGroup.items.length > 1 ? (
               <>
                 <button
@@ -41,6 +40,7 @@ const Nav = ({ navigation, secondaryLinks }) => (
               <Link
                 className="usa-nav__link"
                 activeClassName="usa-current"
+                partiallyActive={navGroup.items[0].link !== '/'}
                 to={navGroup.items[0].link}
               >
                 <span>{navGroup.items[0].text}</span>

--- a/docs/src/components/sidenav.js
+++ b/docs/src/components/sidenav.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 
 const Sidenav = ({ current, headings, items }) => {
   const SidenavItem = ({ link, children }) => {
-    const isSelected = '/' + current === link;
+    const isSelected = current === link;
 
     return (
       <>
@@ -55,10 +55,10 @@ const Sidenav = ({ current, headings, items }) => {
 export const SidenavContributing = (props) => (
   <Sidenav
     items={[
-      { text: 'Contribution Guidelines', link: '/contributing' },
-      { text: 'Development Setup', link: '/setup' },
-      { text: 'Architecture', link: '/architecture' },
-      { text: 'Deployment', link: '/deployment' },
+      { text: 'Contribution Guidelines', link: '/contributing/' },
+      { text: 'Development Setup', link: '/contributing/setup/' },
+      { text: 'Architecture', link: '/contributing/architecture/' },
+      { text: 'Deployment', link: '/contributing/deployment/' },
     ]}
     {...props}
   />
@@ -67,10 +67,10 @@ export const SidenavContributing = (props) => (
 export const SidenavUserGuide = (props) => (
   <Sidenav
     items={[
-      { text: 'Crossfeed Product Overview', link: '/product-overview' },
-      { text: 'Getting Started', link: '/usage' },
-      { text: 'Administration', link: '/administration' },
-      { text: 'Customization', link: '/customization' },
+      { text: 'Crossfeed Product Overview', link: '/usage/product-overview/' },
+      { text: 'Getting Started', link: '/usage/' },
+      { text: 'Administration', link: '/usage/administration/' },
+      { text: 'Customization', link: '/usage/customization/' },
     ]}
     {...props}
   />

--- a/docs/src/documentation-pages/usage/product-overview.md
+++ b/docs/src/documentation-pages/usage/product-overview.md
@@ -3,7 +3,7 @@ title: Crossfeed Product Overview
 sidenav: user-guide
 ---
 
-Crossfeed is a self-service tool that continuously monitors an organization's public-facing attack surface. users can use Crossfeed in order to view a snapshot of their organization's assets from an attacker's perspective and make informed risk decisions about their assets.
+Crossfeed is a self-service tool that continuously monitors an organization's public-facing attack surface. Users can use Crossfeed in order to view a snapshot of their organization's assets from an attacker's perspective and make informed risk decisions about their assets.
 
 ### What Crossfeed does
 

--- a/docs/src/templates/documentation-page.js
+++ b/docs/src/templates/documentation-page.js
@@ -19,10 +19,10 @@ const DocumentationPage = ({ data, location }) => {
         <div className="grid-container">
           <div className="grid-row grid-gap">
             {frontmatter.sidenav === 'contributing' && (
-              <SidenavContributing current={fields.name} headings={headings} />
+              <SidenavContributing current={fields.slug} headings={headings} />
             )}
             {frontmatter.sidenav === 'user-guide' && (
-              <SidenavUserGuide current={fields.name} headings={headings} />
+              <SidenavUserGuide current={fields.slug} headings={headings} />
             )}
             <main
               id="main-content"
@@ -52,7 +52,7 @@ export const pageQuery = graphql`
         sidenav
       }
       fields {
-        name
+        slug
       }
       headings {
         value


### PR DESCRIPTION
- Generate correct slugs based on file path (so `/contributing/deployment/` instead of just `/deployment/`)
- Highlight top nav item when on a subpage:

![image](https://user-images.githubusercontent.com/1689183/110245546-af884300-7f31-11eb-820f-4deb1b5c251f.png)

