### PR TITLE
Increase terraform CI timeout to 72 hours

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -36,6 +36,7 @@ jobs:
         run: terraform fmt -recursive -check -diff
 
   staging:
+    timeout-minutes: 4320
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -72,6 +73,7 @@ jobs:
         run: rm stage.plan || true
 
   prod:
+    timeout-minutes: 4320
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Increase terraform CI timeout to the maximum level of 72 hours. This is because it's taking over 6 hours to delete the S3 webscraper buckets.