### PR TITLE
Fix Granular scans to exclude single scans and update tests 

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -364,7 +364,8 @@ export const listGranular = wrapHandler(async (event) => {
   const scans = await Scan.find({
     select: ['id', 'name', 'isGranular'],
     where: {
-      isGranular: true
+      isGranular: true,
+      isSingleScan: false
     }
   });
   return {

--- a/backend/test/scans.test.ts
+++ b/backend/test/scans.test.ts
@@ -111,8 +111,9 @@ describe('scan', () => {
       expect(
         response.body.scans.map((e) => e.id).indexOf(scan2.id)
       ).toBeGreaterThanOrEqual(-1);
-      expect(response.body.scans.map((e) => e.id).indexOf(scan3.id)
-      ).toEqual(-1);
+      expect(response.body.scans.map((e) => e.id).indexOf(scan3.id)).toEqual(
+        -1
+      );
     });
   });
   describe('create', () => {

--- a/backend/test/scans.test.ts
+++ b/backend/test/scans.test.ts
@@ -93,6 +93,13 @@ describe('scan', () => {
         isGranular: true,
         isSingleScan: false
       }).save();
+      const scan3 = await Scan.create({
+        name: name + '-3',
+        arguments: {},
+        frequency: 999999,
+        isGranular: true,
+        isSingleScan: true
+      }).save();
       const response = await request(app)
         .get('/granularScans')
         .set('Authorization', createUserToken({}))
@@ -104,6 +111,8 @@ describe('scan', () => {
       expect(
         response.body.scans.map((e) => e.id).indexOf(scan2.id)
       ).toBeGreaterThanOrEqual(-1);
+      expect(response.body.scans.map((e) => e.id).indexOf(scan3.id)
+      ).toEqual(-1);
     });
   });
   describe('create', () => {

--- a/backend/test/scans.test.ts
+++ b/backend/test/scans.test.ts
@@ -93,13 +93,6 @@ describe('scan', () => {
         isGranular: true,
         isSingleScan: false
       }).save();
-      const scan3 = await Scan.create({
-        name: name + '-3',
-        arguments: {},
-        frequency: 999999,
-        isGranular: true,
-        isSingleScan: true
-      }).save();
       const response = await request(app)
         .get('/granularScans')
         .set('Authorization', createUserToken({}))
@@ -111,7 +104,29 @@ describe('scan', () => {
       expect(
         response.body.scans.map((e) => e.id).indexOf(scan2.id)
       ).toBeGreaterThanOrEqual(-1);
-      expect(response.body.scans.map((e) => e.id).indexOf(scan3.id)).toEqual(
+    });
+    it('list by regular user should exclude single scans', async () => {
+      const name = 'test-' + Math.random();
+      const scan1 = await Scan.create({
+        name,
+        arguments: {},
+        frequency: 999999,
+        isGranular: true,
+        isSingleScan: false
+      }).save();
+      const scan2 = await Scan.create({
+        name: name + '-2',
+        arguments: {},
+        frequency: 999999,
+        isGranular: true,
+        isSingleScan: true
+      }).save();
+      const response = await request(app)
+        .get('/granularScans')
+        .set('Authorization', createUserToken({}))
+        .expect(200);
+      expect(response.body.scans.length).toBeGreaterThanOrEqual(1);
+      expect(response.body.scans.map((e) => e.id).indexOf(scan2.id)).toEqual(
         -1
       );
     });


### PR DESCRIPTION
Fixes #680 
## 🗣 Description ##

Edited the granular scans api to exclude scans that only run once.
Updated tests to reflect this change

Change was required because the API was returning irrelevant scans.

The tests now check to make sure that no single scans are returned by the API
