### PR TITLE
Fix IIS vulnerability renaming logic

### DIFF
--- a/backend/src/tasks/cve.ts
+++ b/backend/src/tasks/cve.ts
@@ -39,7 +39,8 @@ const productMap = {
   'cpe:/a:microsoft:asp.net': ['cpe:/a:microsoft:.net_framework'],
   'cpe:/a:microsoft:internet_information_server': [
     'cpe:/a:microsoft:internet_information_services'
-  ]
+  ],
+  'cpe:/a:microsoft:iis': ['cpe:/a:microsoft:internet_information_services']
 };
 
 // The number of domains to fetch from the database
@@ -90,18 +91,16 @@ const identifyPassiveCVEsFromCPEs = async (allDomains: Domain[]) => {
         ) {
           const cpe = constructCPE(product.cpe, product.version);
           cpes.add(cpe);
-          if (productMap[product.cpe]) {
-            // Add alternate variants of the CPE as well.
-            for (const productMapCPE in productMap) {
-              if (cpe.indexOf(productMapCPE) > -1) {
-                for (const alternateCPE of productMap[product.cpe]) {
-                  cpes.add(
-                    constructCPE(
-                      cpe.replace(productMapCPE, alternateCPE),
-                      product.version
-                    )
-                  );
-                }
+          // Add alternate variants of the CPE as well.
+          for (const productMapCPE in productMap) {
+            if (cpe.indexOf(productMapCPE) > -1) {
+              for (const alternateCPE of productMap[productMapCPE]) {
+                cpes.add(
+                  constructCPE(
+                    cpe.replace(productMapCPE, alternateCPE),
+                    product.version
+                  )
+                );
               }
             }
           }

--- a/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/cve.test.ts.snap
@@ -50,8 +50,18 @@ Array [
 ]
 `;
 
-exports[`cve product with IIS cpe should include alternate cpes defined in productMap: execSync.input 1`] = `
+exports[`cve product with IIS cpe cpe:/a:microsoft:iis:2.5 should include alternate cpes defined in productMap: execSync.input 1`] = `
+"0 cpe:/a:microsoft:iis:2.5,cpe:/a:microsoft:internet_information_services:2.5
+"
+`;
+
+exports[`cve product with IIS cpe cpe:/a:microsoft:internet_information_server should include alternate cpes defined in productMap: execSync.input 1`] = `
 "0 cpe:/a:microsoft:internet_information_server:7.5,cpe:/a:microsoft:internet_information_services:7.5
+"
+`;
+
+exports[`cve product with IIS cpe cpe:/a:microsoft:internet_information_server:8.5 should include alternate cpes defined in productMap: execSync.input 1`] = `
+"0 cpe:/a:microsoft:internet_information_server:8.5,cpe:/a:microsoft:internet_information_services:8.5
 "
 `;
 

--- a/backend/src/tasks/test/cve.test.ts
+++ b/backend/src/tasks/test/cve.test.ts
@@ -330,37 +330,53 @@ describe('cve', () => {
     ]);
   });
 
-  test('product with IIS cpe should include alternate cpes defined in productMap', async () => {
-    const organization = await Organization.create({
-      name: 'test-' + Math.random(),
-      rootDomains: ['test-' + Math.random()],
-      ipBlocks: [],
-      isPassive: false
-    }).save();
-    const name = 'test-' + Math.random();
-    const domain = await Domain.create({
-      name,
-      organization
-    }).save();
-    const service = await Service.create({
-      domain,
-      port: 80,
-      wappalyzerResults: [
-        {
-          technology: {
-            cpe: 'cpe:/a:microsoft:internet_information_server'
-          },
-          version: '7.5'
-        }
-      ]
-    }).save();
-    await cve({
-      organizationId: organization.id,
-      scanId: 'scanId',
-      scanName: 'scanName',
-      scanTaskId: 'scanTaskId'
+  const technologies = [
+    {
+      technology: {
+        cpe: 'cpe:/a:microsoft:internet_information_server'
+      },
+      version: '7.5'
+    },
+    {
+      technology: {
+        cpe: 'cpe:/a:microsoft:internet_information_server:8.5'
+      },
+      version: '8.5'
+    },
+    {
+      technology: {
+        cpe: 'cpe:/a:microsoft:iis:2.5'
+      },
+      version: '2.5'
+    }
+  ];
+  for (const technology of technologies) {
+    test(`product with IIS cpe ${technology.technology.cpe} should include alternate cpes defined in productMap`, async () => {
+      const organization = await Organization.create({
+        name: 'test-' + Math.random(),
+        rootDomains: ['test-' + Math.random()],
+        ipBlocks: [],
+        isPassive: false
+      }).save();
+      const name = 'test-' + Math.random();
+      const domain = await Domain.create({
+        name,
+        organization
+      }).save();
+      const service = await Service.create({
+        domain,
+        port: 80,
+        wappalyzerResults: [technology]
+      }).save();
+
+      await cve({
+        organizationId: organization.id,
+        scanId: 'scanId',
+        scanName: 'scanName',
+        scanTaskId: 'scanTaskId'
+      });
     });
-  });
+  }
 
   test('should exit if no matching domains with cpes', async () => {
     const organization = await Organization.create({


### PR DESCRIPTION
Fix IIS vulnerability renaming logic, as the old logic wasn't properly working for cpes with version numbers and the cpe `cpe:/a:microsoft:iis`.

For https://github.com/cisagov/crossfeed/issues/961