### PR TITLE
Simplify syncdb command

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -84,7 +84,7 @@
     "build-worker": "./tools/build-worker.sh",
     "deploy-worker-staging": "./tools/deploy-worker.sh",
     "deploy-worker-prod": "./tools/deploy-worker.sh crossfeed-prod-worker",
-    "syncdb": "ts-node src/tools/run-syncdb.ts"
+    "syncdb": "docker-compose exec backend npx ts-node src/tools/run-syncdb.ts"
   },
   "author": "",
   "license": "ISC"

--- a/backend/package.json
+++ b/backend/package.json
@@ -84,7 +84,7 @@
     "build-worker": "./tools/build-worker.sh",
     "deploy-worker-staging": "./tools/deploy-worker.sh",
     "deploy-worker-prod": "./tools/deploy-worker.sh crossfeed-prod-worker",
-    "syncdb": "docker-compose exec backend npx ts-node src/tools/run-syncdb.ts"
+    "syncdb": "docker-compose exec -T backend npx ts-node src/tools/run-syncdb.ts"
   },
   "author": "",
   "license": "ISC"

--- a/docs/src/documentation-pages/dev/database.md
+++ b/docs/src/documentation-pages/dev/database.md
@@ -39,17 +39,6 @@ you want to update the database schemas.
 ```bash
 cd backend
 # Generate schema
-docker-compose exec backend npx sls invoke local -f syncdb
-# Populate sample data
-docker-compose exec backend npx sls invoke local -f syncdb -d populate
-```
-
-If you are using Node 14, you might be able to run the following commands to
-sync a bit faster (without needing to wait for compilation):
-
-```bash
-cd backend && npm install
-# Generate schema
 npm run syncdb
 # Populate sample data
 npm run syncdb -- -d populate

--- a/docs/src/documentation-pages/dev/quickstart.md
+++ b/docs/src/documentation-pages/dev/quickstart.md
@@ -32,9 +32,9 @@ This quickstart describes the initial setup required to run an instance of Cross
    ```bash
    cd backend
    # Generate schema
-   docker-compose exec backend npx sls invoke local -f syncdb
+   npm run syncdb
    # Populate sample data
-   docker-compose exec backend npx sls invoke local -f syncdb -d populate
+   npm run syncdb -- -d populate
    ```
 
    If you ever need to drop and recreate the database, you can run `npm run syncdb -- -d dangerouslyforce`.


### PR DESCRIPTION
Simplify syncdb command so the user can just run `npm run syncdb` again (instead of copy-and-pasting a long `docker compose` command).