### PR TITLE
Increase cpu, memory for shodan scan

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -89,7 +89,9 @@ export const SCAN_SCHEMA: ScanSchema = {
     isPassive: true,
     global: false,
     description:
-      'Fetch passive port, banner, and vulnerability data from shodan'
+      'Fetch passive port, banner, and vulnerability data from shodan',
+    cpu: '1024',
+    memory: '8192'
   },
   sslyze: {
     type: 'fargate',


### PR DESCRIPTION
The shodan scan is getting killed due to a lack of memory. This PR increases cpu, memory for the shodan scan to make it more robust.