### PR TITLE
Save vulnerability data from shodan

### DIFF
--- a/backend/src/tasks/shodan.ts
+++ b/backend/src/tasks/shodan.ts
@@ -106,30 +106,29 @@ export const handler = async (commandOptions: CommandOptions) => {
               })
             ]);
             if (service.vulns) {
-              // Don't create vulns from shodan now -- too many false positives.
-              // console.log('creating vulnerability');
-              // const vulns: Vulnerability[] = [];
-              // for (const cve in service.vulns) {
-              //   vulns.push(
-              //     plainToClass(Vulnerability, {
-              //       domain: domain,
-              //       lastSeen: new Date(Date.now()),
-              //       title: cve,
-              //       cve: cve,
-              //       cpe:
-              //         service.cpe && service.cpe.length > 0
-              //           ? service.cpe[0]
-              //           : null,
-              //       cvss: service.vulns[cve].cvss,
-              //       state: 'open',
-              //       source: 'shodan',
-              //       description: service.vulns[cve].summary,
-              //       needsPopulation: true,
-              //       service: { id: serviceId }
-              //     })
-              //   );
-              // }
-              // await saveVulnerabilitiesToDb(vulns, false);
+              const vulns: Vulnerability[] = [];
+              for (const cve in service.vulns) {
+                // console.log('Creating vulnerability', cve);
+                vulns.push(
+                  plainToClass(Vulnerability, {
+                    domain: domain,
+                    lastSeen: new Date(Date.now()),
+                    title: cve,
+                    cve: cve,
+                    // cpe:
+                    //   service.cpe && service.cpe.length > 0
+                    //     ? service.cpe[0]
+                    //     : null,
+                    cvss: service.vulns[cve].cvss,
+                    state: 'open',
+                    source: 'shodan',
+                    description: service.vulns[cve].summary,
+                    needsPopulation: true,
+                    service: { id: serviceId }
+                  })
+                );
+              }
+              await saveVulnerabilitiesToDb(vulns, false);
             }
           }
         }

--- a/backend/src/tasks/shodan.ts
+++ b/backend/src/tasks/shodan.ts
@@ -115,6 +115,8 @@ export const handler = async (commandOptions: CommandOptions) => {
                     lastSeen: new Date(Date.now()),
                     title: cve,
                     cve: cve,
+                    // Shodan CPE information is unreliable,
+                    // so don't add it in for now.
                     // cpe:
                     //   service.cpe && service.cpe.length > 0
                     //     ? service.cpe[0]
@@ -122,7 +124,6 @@ export const handler = async (commandOptions: CommandOptions) => {
                     cvss: service.vulns[cve].cvss,
                     state: 'open',
                     source: 'shodan',
-                    description: service.vulns[cve].summary,
                     needsPopulation: true,
                     service: { id: serviceId }
                   })

--- a/backend/src/tasks/test/shodan.test.ts
+++ b/backend/src/tasks/test/shodan.test.ts
@@ -227,7 +227,7 @@ describe('shodan', () => {
     });
     await checkDomains(organization);
   });
-  test.skip('creates vulnerability', async () => {
+  test('creates vulnerability', async () => {
     nock('https://api.shodan.io')
       .get(
         `/shodan/host/153.126.148.60,31.134.10.156,1.1.1.1?key=${process.env.SHODAN_API_KEY}`


### PR DESCRIPTION
Save vulnerability data from shodan. I had disabled this earlier because it was a bit unreliable, but I think with a few changes, we're ready to enable it again. This will allow us to bring in vulnerability data from shodan (such as data from the latest Exchange vulnerabilities).

I also add additional logic to `saveVulnerabilitiesToDb` so that vulnerability data from shodan doesn't inadvertently overwrite vulnerability data from other sources, such as the cpe2cve tool.