### PR TITLE
Fix last logged in bug for user table

### DIFF
--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -14,7 +14,7 @@ import { Column } from 'react-table';
 import { User } from 'types';
 import { FaTimes } from 'react-icons/fa';
 import { useAuthContext } from 'context';
-import { formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow, parseISO } from 'date-fns';
 
 interface Errors extends Partial<User> {
   global?: string;
@@ -69,7 +69,7 @@ export const Users: React.FC = () => {
     },
     {
       Header: 'Date ToU Signed',
-      accessor: ({ dateAcceptedTerms }) => dateAcceptedTerms,
+      accessor: ({ dateAcceptedTerms }) => dateAcceptedTerms ? `${formatDistanceToNow(parseISO(dateAcceptedTerms))} ago` : "None",
       width: 50,
       minWidth: 50,
       id: 'dateAcceptedTerms',
@@ -85,7 +85,7 @@ export const Users: React.FC = () => {
     },
     {
       Header: 'Last Logged In',
-      accessor: ({ lastLoggedIn }) => (lastLoggedIn ? `${formatDistanceToNow(lastLoggedIn)} ago` : "None"),
+      accessor: ({ lastLoggedIn }) => lastLoggedIn ? `${formatDistanceToNow(parseISO(lastLoggedIn))} ago` : "None",
       width: 50,
       minWidth: 50,
       id: 'lastLoggedIn',

--- a/frontend/src/test-utils/user.ts
+++ b/frontend/src/test-utils/user.ts
@@ -4,7 +4,7 @@ export const testUser: AuthUser = {
   id: 'd7d6e913-0370-4f43-aebc-6bd727adc70e',
   createdAt: '2020-08-23T03:36:57.231Z',
   updatedAt: '2020-08-23T03:36:57.231Z',
-  lastLoggedIn: new Date(),
+  lastLoggedIn: new Date().toISOString(),
   firstName: 'John',
   lastName: 'Smith',
   fullName: 'John Smith',
@@ -12,7 +12,7 @@ export const testUser: AuthUser = {
   userType: 'standard',
   email: 'test@crossfeed.gov',
   roles: [],
-  dateAcceptedTerms: new Date(),
+  dateAcceptedTerms: new Date().toISOString(),
   acceptedTermsVersion: 'v1-user',
   isRegistered: true,
   apiKeys: []

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -12,8 +12,8 @@ export interface User {
   userType: 'standard' | 'globalView' | 'globalAdmin';
   email: string;
   roles: Role[];
-  dateAcceptedTerms: Date | null;
+  dateAcceptedTerms: string | null;
   acceptedTermsVersion: string | null;
-  lastLoggedIn: Date | null;
+  lastLoggedIn: string | null;
   apiKeys: ApiKey[];
 }


### PR DESCRIPTION
## 🗣 Description ##

Fixes https://github.com/cisagov/crossfeed/issues/1049. `lastLoggedIn` is an ISO String, not a date, so this PR changes the typing accordingly.

It looks like `dateAcceptedTerms` was also earlier incorrectly typed as a date rather than a string, so I've changed that as well and formatted this date in the user table with `formatDistanceToNow` as well.