### PR TITLE
Navbar "scans" tab disappears when screen size is too small #979

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -174,10 +174,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
                 alt="Crossfeed Icon Navigate Home"
               />
             </Link>
-            <div className={classes.mdNav}>{desktopNavItems.slice(0, 3)}</div>
-            <div className={classes.lgNav}>
-              {desktopNavItems.slice(3, navItems.length)}
-            </div>
+            <div className={classes.lgNav}>{desktopNavItems.slice()}</div>
 
             <div className={classes.spacing} />
 
@@ -330,7 +327,7 @@ const useStyles = makeStyles((theme) => ({
   menuButton: {
     marginRight: theme.spacing(2),
     display: 'block',
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up(1330)]: {
       display: 'none'
     }
   },
@@ -389,16 +386,10 @@ const useStyles = makeStyles((theme) => ({
     border: 'none',
     textDecoration: 'none'
   },
-  mdNav: {
-    display: 'none',
-    [theme.breakpoints.up('md')]: {
-      display: 'block'
-    }
-  },
   lgNav: {
     display: 'none',
-    [theme.breakpoints.up('lg')]: {
-      display: 'block'
+    [theme.breakpoints.up(1330)]: {
+      display: 'inline'
     }
   },
   mobileNav: {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -327,7 +327,7 @@ const useStyles = makeStyles((theme) => ({
   menuButton: {
     marginRight: theme.spacing(2),
     display: 'block',
-    [theme.breakpoints.up(1330)]: {
+    [theme.breakpoints.up('lg')]: {
       display: 'none'
     }
   },
@@ -388,7 +388,7 @@ const useStyles = makeStyles((theme) => ({
   },
   lgNav: {
     display: 'none',
-    [theme.breakpoints.up(1330)]: {
+    [theme.breakpoints.up('lg')]: {
       display: 'inline'
     }
   },

--- a/frontend/src/components/__tests__/__snapshots__/header.spec.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/header.spec.tsx.snap
@@ -46,25 +46,25 @@ exports[`Header component matches snapshot 1`] = `
             />
           </a>
           <div
-            class="makeStyles-mdNav-9"
+            class="makeStyles-lgNav-9"
           >
             <a
               aria-current="page"
-              class="makeStyles-link-18 makeStyles-activeLink-16"
+              class="makeStyles-link-17 makeStyles-activeLink-15"
               href="/"
               style="outline: none;"
             >
               Overview
             </a>
             <a
-              class="makeStyles-link-18"
+              class="makeStyles-link-17"
               href="/inventory"
               style="outline: none;"
             >
               Inventory
             </a>
             <a
-              class="makeStyles-link-18"
+              class="makeStyles-link-17"
               href="/feeds"
               style="outline: none;"
             >
@@ -72,20 +72,17 @@ exports[`Header component matches snapshot 1`] = `
             </a>
           </div>
           <div
-            class="makeStyles-lgNav-10"
-          />
-          <div
             class="makeStyles-spacing-4"
           />
           <div
-            class="makeStyles-wrapper-20"
+            class="makeStyles-wrapper-19"
           >
             <div
-              class="makeStyles-inner-21"
+              class="makeStyles-inner-20"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-icon-23"
+                class="MuiSvgIcon-root makeStyles-icon-22"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -95,7 +92,7 @@ exports[`Header component matches snapshot 1`] = `
               </svg>
               <form>
                 <input
-                  class="makeStyles-inp-22"
+                  class="makeStyles-inp-21"
                   placeholder="Search for a domain, vuln type, port, service, IP"
                   value=""
                 />
@@ -104,7 +101,7 @@ exports[`Header component matches snapshot 1`] = `
           </div>
           <a
             aria-current="page"
-            class="makeStyles-link-18 makeStyles-link-18"
+            class="makeStyles-link-17 makeStyles-link-17"
             href="/"
             style="outline: none;"
           >

--- a/frontend/src/context/Theme.tsx
+++ b/frontend/src/context/Theme.tsx
@@ -15,6 +15,15 @@ const theme = createMuiTheme({
     background: {
       default: '#EFF1F5'
     }
+  },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 960,
+      lg: 1330,
+      xl: 1920
+    }
   }
 });
 


### PR DESCRIPTION
fixes #979 

All 4 NavItems only fit side by side when the screen width is 1330px or greater.

The original code tried to fix this by hiding  the "scan" nav item when the screen width was <1280px ('lg'). Instead of hiding one of the navItems, I made the sidebar button accessible until all four can be shown side-by-side. 

See changes at width: 1330px below:
<img width="1544" alt="Screen Shot 2021-04-02 at 10 27 07 AM" src="https://user-images.githubusercontent.com/79927030/113424643-7e6b2900-939e-11eb-96c9-de6992b0bbce.png">
<img width="1352" alt="Screen Shot 2021-04-02 at 10 27 10 AM" src="https://user-images.githubusercontent.com/79927030/113424665-84f9a080-939e-11eb-99ad-128fbc4f5234.png">
