### PR TITLE
Search results - domain preview should hide when there are "no result… fixes #1027

### DIFF
--- a/frontend/src/pages/Search/Dashboard.tsx
+++ b/frontend/src/pages/Search/Dashboard.tsx
@@ -211,7 +211,7 @@ export const DashboardUI: React.FC<ContextType & { location: any }> = (
             ))}
           </div>
           <div className={classes.panel}>
-            {selectedDomain && <DomainDetails domainId={selectedDomain} />}
+            {selectedDomain && !noResults && <DomainDetails domainId={selectedDomain} />}
           </div>
         </div>
         <Paper classes={{ root: classes.pagination }}>


### PR DESCRIPTION
#1027

Fixes the issue, but still working on hiding the selectedDomain when a new search is executed (with results).
