### PR TITLE
Fix endpoints for syncdb

### DIFF
--- a/backend/src/tools/run-syncdb.ts
+++ b/backend/src/tools/run-syncdb.ts
@@ -8,9 +8,9 @@ import { handler as syncdb } from '../tasks/syncdb';
  * with some sample data.
  * */
 
-process.env.DB_HOST = 'localhost';
+process.env.DB_HOST = 'db';
 process.env.DB_USERNAME = 'crossfeed';
 process.env.DB_PASSWORD = 'password';
-process.env.ELASTICSEARCH_ENDPOINT = 'http://localhost:9200';
+process.env.ELASTICSEARCH_ENDPOINT = 'http://es:9200';
 
 syncdb(process.argv[2] === '-d' ? process.argv[3] : '', {} as any, () => null);


### PR DESCRIPTION
Sorry, I didn't test https://github.com/cisagov/crossfeed/pull/1036 properly -- we need to fix the endpoints for syncdb because it's now being run from within the backend docker container (so the endpoints for the database and elasticsearch should be `db` and `es`, respectively, not `localhost`).