### PR TITLE
Add Breach Data to HIBP Scan

### DIFF
--- a/backend/src/tasks/hibp.ts
+++ b/backend/src/tasks/hibp.ts
@@ -17,12 +17,11 @@ async function lookupEmails(breachesDict: any, domain: Domain) {
       domain.name,
     {
       headers: {
-        Authorization: 'Bearer ' + process.env.HIBP_API_KEY! 
-
+        Authorization: 'Bearer ' + process.env.HIBP_API_KEY!
       }
     }
   ).json();
-  
+
   const AddressResults = {};
   const BreachResults = {};
   const finalResults = {};
@@ -40,13 +39,13 @@ async function lookupEmails(breachesDict: any, domain: Domain) {
       AddressResults[email + '@' + domain.name] = filtered;
       for (const breach of filtered) {
         if (!(breach in BreachResults)) {
-          BreachResults[breach] = breachesDict[breach]
+          BreachResults[breach] = breachesDict[breach];
         }
       }
     }
   }
-  finalResults["Emails"] = AddressResults;
-  finalResults["Breaches"] = BreachResults;
+  finalResults['Emails'] = AddressResults;
+  finalResults['Breaches'] = BreachResults;
   return finalResults;
 }
 
@@ -75,10 +74,12 @@ export const handler = async (commandOptions: CommandOptions) => {
   for (const domain of domainsWithIPs) {
     const results = await lookupEmails(breachesDict, domain);
     console.log(
-      `Got ${Object.keys(results["Emails"]).length} emails for domain ${domain.name}`
+      `Got ${Object.keys(results['Emails']).length} emails for domain ${
+        domain.name
+      }`
     );
 
-    if (Object.keys(results["Emails"]).length !== 0) {
+    if (Object.keys(results['Emails']).length !== 0) {
       vulns.push(
         plainToClass(Vulnerability, {
           domain: domain,
@@ -87,16 +88,16 @@ export const handler = async (commandOptions: CommandOptions) => {
           state: 'open',
           source: 'hibp',
           needsPopulation: false,
-          structuredData: { 
-            emails: results["Emails"],
-            breaches: results["Breaches"]
-           },
+          structuredData: {
+            emails: results['Emails'],
+            breaches: results['Breaches']
+          },
           description: `Emails associated with ${domain.name} have been exposed in a breach.`
         })
       );
       await saveVulnerabilitiesToDb(vulns, false);
-      console.log(results["Emails"]);
-      console.log(results["Breaches"]);
+      console.log(results['Emails']);
+      console.log(results['Breaches']);
     }
   }
 };

--- a/backend/src/tasks/hibp.ts
+++ b/backend/src/tasks/hibp.ts
@@ -17,11 +17,14 @@ async function lookupEmails(breachesDict: any, domain: Domain) {
       domain.name,
     {
       headers: {
-        Authorization: 'Bearer ' + process.env.HIBP_API_KEY!
+        Authorization: 'Bearer ' + process.env.HIBP_API_KEY! 
+
       }
     }
   ).json();
-
+  
+  const AddressResults = {};
+  const BreachResults = {};
   const finalResults = {};
 
   const shouldCountBreach = (breach) =>
@@ -34,10 +37,16 @@ async function lookupEmails(breachesDict: any, domain: Domain) {
       shouldCountBreach(breachesDict[e])
     );
     if (filtered.length > 0) {
-      finalResults[email + '@' + domain.name] = filtered;
+      AddressResults[email + '@' + domain.name] = filtered;
+      for (const breach of filtered) {
+        if (!(breach in BreachResults)) {
+          BreachResults[breach] = breachesDict[breach]
+        }
+      }
     }
   }
-
+  finalResults["Emails"] = AddressResults;
+  finalResults["Breaches"] = BreachResults;
   return finalResults;
 }
 
@@ -66,10 +75,10 @@ export const handler = async (commandOptions: CommandOptions) => {
   for (const domain of domainsWithIPs) {
     const results = await lookupEmails(breachesDict, domain);
     console.log(
-      `Got ${Object.keys(results).length} emails for domain ${domain.name}`
+      `Got ${Object.keys(results["Emails"]).length} emails for domain ${domain.name}`
     );
 
-    if (Object.keys(results).length !== 0) {
+    if (Object.keys(results["Emails"]).length !== 0) {
       vulns.push(
         plainToClass(Vulnerability, {
           domain: domain,
@@ -78,12 +87,16 @@ export const handler = async (commandOptions: CommandOptions) => {
           state: 'open',
           source: 'hibp',
           needsPopulation: false,
-          structuredData: { emails: results },
+          structuredData: { 
+            emails: results["Emails"],
+            breaches: results["Breaches"]
+           },
           description: `Emails associated with ${domain.name} have been exposed in a breach.`
         })
       );
       await saveVulnerabilitiesToDb(vulns, false);
-      console.log(results);
+      console.log(results["Emails"]);
+      console.log(results["Breaches"]);
     }
   }
 };

--- a/backend/src/tasks/sample_data/vulnerabilities.json
+++ b/backend/src/tasks/sample_data/vulnerabilities.json
@@ -878,13 +878,161 @@
         "state": "open",
         "substate": "unconfirmed",
         "source": "hibp",
-        "structuredData": { "emails": {
+        "structuredData": { 
+        "emails": {
             "Email_11@crossfeed.local":["breach12","breach17"],
             "Email_13@crossfeed.local":["breach14","breach3"],
             "Email_64@crossfeed.local":["breach24"],
             "Email_32@crossfeed.local":["breach22"],
             "Email_17@crossfeed.local":["breach54","breach2"]
-        } },
+        },
+        "breaches":{
+            "breach_12": {
+                "Name": "Breach_12",
+                "Title": "Breach_12",
+                "Domain": "Breach_12.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 12",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_12.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_17": {
+                "Name": "Breach_17",
+                "Title": "Breach_17",
+                "Domain": "Breach_17.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 17",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_17.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_14": {
+                "Name": "Breach_14",
+                "Title": "Breach_14",
+                "Domain": "Breach_14.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 14",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_14.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_3": {
+                "Name": "Breach_3",
+                "Title": "Breach_3",
+                "Domain": "Breach_3.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 3",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_12.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_25": {
+                "Name": "Breach_24",
+                "Title": "Breach_24",
+                "Domain": "Breach_24.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 24",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_24.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_22": {
+                "Name": "Breach_22",
+                "Title": "Breach_22",
+                "Domain": "Breach_22.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 22",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_22.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_54": {
+                "Name": "Breach_54",
+                "Title": "Breach_54",
+                "Domain": "Breach_54.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 54",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_54.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_2": {
+                "Name": "Breach_2",
+                "Title": "Breach_2",
+                "Domain": "Breach_2.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 2",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_2.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              }
+        }
+     },
         "notes": "",
         "actions": []
     },
@@ -900,13 +1048,161 @@
         "state": "open",
         "substate": "unconfirmed",
         "source": "hibp",
-        "structuredData": { "emails": {
+        "structuredData": {
+            "emails": {
             "Email_18@crossfeed.local":["breach16","breach17"],
             "Email_14@crossfeed.local":["breach764","breach87"],
             "Email_98@crossfeed.local":["breach32"],
             "Email_34@crossfeed.local":["breach45"],
             "Email_65@crossfeed.local":["breach76","breach2"]
-        } },
+        },
+        "breaches":{
+            "breach_16": {
+                "Name": "Breach_16",
+                "Title": "Breach_16",
+                "Domain": "Breach_16.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 16",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_16.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_17": {
+                "Name": "Breach_17",
+                "Title": "Breach_17",
+                "Domain": "Breach_17.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 17",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_17.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_764": {
+                "Name": "Breach_764",
+                "Title": "Breach_764",
+                "Domain": "Breach_764.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 764",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_764.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_87": {
+                "Name": "Breach_87",
+                "Title": "Breach_87",
+                "Domain": "Breach_87.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 87",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_87.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_32": {
+                "Name": "Breach_32",
+                "Title": "Breach_32",
+                "Domain": "Breach_32.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 32",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_32.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_45": {
+                "Name": "Breach_45",
+                "Title": "Breach_45",
+                "Domain": "Breach_45.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 45",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_45.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_76": {
+                "Name": "Breach_76",
+                "Title": "Breach_76",
+                "Domain": "Breach_76.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 76",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_76.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              },
+              "breach_2": {
+                "Name": "Breach_2",
+                "Title": "Breach_2",
+                "Domain": "Breach_2.com",
+                "BreachDate": "2017-02-01",
+                "AddedDate": "2017-10-26T23:35:45Z",
+                "ModifiedDate": "2017-12-10T21:44:27Z",
+                "PwnCount": 8393093,
+                "Description": "Mock Breach number 2",
+                "LogoPath":
+                  "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_2.png",
+                "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                "IsVerified": true,
+                "IsFabricated": false,
+                "IsSensitive": false,
+                "IsRetired": false,
+                "IsSpamList": false
+              }
+        }
+    },
         "notes": "",
         "actions": []
     },
@@ -922,12 +1218,160 @@
         "state": "open",
         "substate": "unconfirmed",
         "source": "hibp",
-        "structuredData": { "emails": {
+        "structuredData": { 
+        "emails": {
             "Email_15@crossfeed.local":["breach25","breach17"],
             "Email_32@crossfeed.local":["breach4","breach87"],
             "Email_76@crossfeed.local":["breach374"],
             "Email_13@crossfeed.local":["breach13"],
             "Email_62@crossfeed.local":["breach54","breach2"]
+        },
+            "breaches":{
+                "breach_25": {
+                    "Name": "Breach_25",
+                    "Title": "Breach_25",
+                    "Domain": "Breach_25.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 25",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_25.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_17": {
+                    "Name": "Breach_17",
+                    "Title": "Breach_17",
+                    "Domain": "Breach_17.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 17",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_17.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_4": {
+                    "Name": "Breach_4",
+                    "Title": "Breach_4",
+                    "Domain": "Breach_4.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 4",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_4.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_87": {
+                    "Name": "Breach_87",
+                    "Title": "Breach_87",
+                    "Domain": "Breach_87.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 87",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_87.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_374": {
+                    "Name": "Breach_374",
+                    "Title": "Breach_374",
+                    "Domain": "Breach_374.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 374",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_374.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_13": {
+                    "Name": "Breach_13",
+                    "Title": "Breach_13",
+                    "Domain": "Breach_13.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 13",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_13.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_54": {
+                    "Name": "Breach_54",
+                    "Title": "Breach_54",
+                    "Domain": "Breach_54.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 54",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_54.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  },
+                  "breach_2": {
+                    "Name": "Breach_2",
+                    "Title": "Breach_2",
+                    "Domain": "Breach_2.com",
+                    "BreachDate": "2017-02-01",
+                    "AddedDate": "2017-10-26T23:35:45Z",
+                    "ModifiedDate": "2017-12-10T21:44:27Z",
+                    "PwnCount": 8393093,
+                    "Description": "Mock Breach number 2",
+                    "LogoPath":
+                      "https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_2.png",
+                    "DataClasses": ["Email addresses", "IP addresses", "Names", "Passwords"],
+                    "IsVerified": true,
+                    "IsFabricated": false,
+                    "IsSensitive": false,
+                    "IsRetired": false,
+                    "IsSpamList": false
+                  }
+
         } },
         "notes": "",
         "actions": []

--- a/backend/src/tasks/test/hibp.test.ts
+++ b/backend/src/tasks/test/hibp.test.ts
@@ -365,14 +365,19 @@ describe('hibp', () => {
             Description: 'Mock Breach number 1',
             LogoPath:
               'https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_1.png',
-            DataClasses: ['Email addresses', 'IP addresses', 'Names', 'Passwords'],
+            DataClasses: [
+              'Email addresses',
+              'IP addresses',
+              'Names',
+              'Passwords'
+            ],
             IsVerified: true,
             IsFabricated: false,
             IsSensitive: false,
             IsRetired: false,
             IsSpamList: false
           },
-          Breach_2:{
+          Breach_2: {
             Name: 'Breach_2',
             Title: 'Breach_2',
             Domain: 'Breach_2.com',
@@ -398,7 +403,7 @@ describe('hibp', () => {
             IsRetired: false,
             IsSpamList: false
           },
-          Breach_3:{
+          Breach_3: {
             Name: 'Breach_3',
             Title: 'Breach_3',
             Domain: 'Breach_3.com',
@@ -416,7 +421,7 @@ describe('hibp', () => {
             IsRetired: false,
             IsSpamList: false
           },
-          Breach_4:{
+          Breach_4: {
             Name: 'Breach_4',
             Title: 'Breach_4',
             Domain: 'Breach_4.com',
@@ -497,9 +502,9 @@ describe('hibp', () => {
     expect(
       vulns[0].structuredData['emails']['testEmail_2@test-domain_1']
     ).toEqual(['Breach_4']);
-    expect(
-      vulns[0].structuredData['breaches']['Breach_1']['PwnCount']
-    ).toEqual(8393093);
+    expect(vulns[0].structuredData['breaches']['Breach_1']['PwnCount']).toEqual(
+      8393093
+    );
     expect(vulns[0].updatedAt).not.toEqual(vulnerability.updatedAt);
   });
 });

--- a/backend/src/tasks/test/hibp.test.ts
+++ b/backend/src/tasks/test/hibp.test.ts
@@ -352,6 +352,94 @@ describe('hibp', () => {
           testEmail_2: ['Breach_2'],
           testEmail_3: ['Breach_3'],
           testEmail_4: ['Breach_4']
+        },
+        breaches: {
+          breach_1: {
+            Name: 'Breach_1',
+            Title: 'Breach_1',
+            Domain: 'Breach_1.com',
+            BreachDate: '2017-02-01',
+            AddedDate: '2017-10-26T23:35:45Z',
+            ModifiedDate: '2017-12-10T21:44:27Z',
+            PwnCount: 8393093,
+            Description: 'Mock Breach number 1',
+            LogoPath:
+              'https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_1.png',
+            DataClasses: ['Email addresses', 'IP addresses', 'Names', 'Passwords'],
+            IsVerified: true,
+            IsFabricated: false,
+            IsSensitive: false,
+            IsRetired: false,
+            IsSpamList: false
+          },
+          Breach_2:{
+            Name: 'Breach_2',
+            Title: 'Breach_2',
+            Domain: 'Breach_2.com',
+            BreachDate: '2020-03-22',
+            AddedDate: '2020-11-15T00:59:50Z',
+            ModifiedDate: '2020-11-15T01:07:10Z',
+            PwnCount: 8661578,
+            Description: 'Mock Breach number 2',
+            LogoPath:
+              'https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_2.png',
+            DataClasses: [
+              'Email addresses',
+              'IP addresses',
+              'Names',
+              'Passwords',
+              'Phone numbers',
+              'Physical addresses',
+              'Usernames'
+            ],
+            IsVerified: true,
+            IsFabricated: false,
+            IsSensitive: false,
+            IsRetired: false,
+            IsSpamList: false
+          },
+          Breach_3:{
+            Name: 'Breach_3',
+            Title: 'Breach_3',
+            Domain: 'Breach_3.com',
+            BreachDate: '2012-01-01',
+            AddedDate: '2016-10-08T07:46:05Z',
+            ModifiedDate: '2016-10-08T07:46:05Z',
+            PwnCount: 6414191,
+            Description: 'Mock Breach number 3',
+            LogoPath:
+              'https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_3.png',
+            DataClasses: ['Email addresses', 'Passwords'],
+            IsVerified: false,
+            IsFabricated: false,
+            IsSensitive: false,
+            IsRetired: false,
+            IsSpamList: false
+          },
+          Breach_4:{
+            Name: 'Breach_4',
+            Title: 'Breach_4',
+            Domain: 'Breach_4.com',
+            BreachDate: '2016-04-19',
+            AddedDate: '2016-07-08T01:55:03Z',
+            ModifiedDate: '2016-07-08T01:55:03Z',
+            PwnCount: 4009640,
+            Description: 'Mock Breach number 4',
+            LogoPath:
+              'https://haveibeenpwned.com/Content/Images/PwnedLogos/Breach_4.png',
+            DataClasses: [
+              'Device information',
+              'Email addresses',
+              'IP addresses',
+              'Passwords',
+              'Usernames'
+            ],
+            IsVerified: true,
+            IsFabricated: false,
+            IsSensitive: false,
+            IsRetired: false,
+            IsSpamList: false
+          }
         }
       },
       substate: 'remediated',
@@ -409,6 +497,9 @@ describe('hibp', () => {
     expect(
       vulns[0].structuredData['emails']['testEmail_2@test-domain_1']
     ).toEqual(['Breach_4']);
+    expect(
+      vulns[0].structuredData['breaches']['Breach_1']['PwnCount']
+    ).toEqual(8393093);
     expect(vulns[0].updatedAt).not.toEqual(vulnerability.updatedAt);
   });
 });


### PR DESCRIPTION
Fixes #1075
In order to Generate P&E reports the HIBP data needs to have data about each breach. This update adds the breach data to structured data field in the vulnerability model alongside the exposed emails
