### PR TITLE
A5 - Text and Search Icon Color

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -126,6 +126,9 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '1rem',
     fontWeight: 300,
     background: 'none',
+    "&::placeholder": {
+      color: '#71767A'
+    },
     '&:focus': {
       outline: 'none !important'
     }
@@ -136,7 +139,7 @@ const useStyles = makeStyles((theme) => ({
     top: '50%',
     transform: 'translateY(-50%)',
     fontSize: '1.5rem',
-    color: theme.palette.grey[300]
+    color: '#71767A'
   },
   autocompleteRoot: {
     position: 'absolute',


### PR DESCRIPTION
fixes #1083

Changed the search icon and preview text colors:

Original:
<img width="433" alt="Screen Shot 2021-04-30 at 2 48 07 PM" src="https://user-images.githubusercontent.com/79927030/116740523-233f4d00-a9c3-11eb-8587-b5cd85083d27.png">

Fix:
<img width="492" alt="Screen Shot 2021-04-30 at 2 47 52 PM" src="https://user-images.githubusercontent.com/79927030/116740529-263a3d80-a9c3-11eb-8738-f8280ab20457.png">
