### PR TITLE
Add security pipeline to periodically check for vulnerabilities

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,25 +21,6 @@ defaults:
     working-directory: ./backend
 
 jobs:
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2.1.5
-        with:
-          node-version: '14'
-      - name: Restore npm cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Install dependencies
-        run: npm ci
-      - name: Security
-        run: npm audit
-        continue-on-error: true
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -99,7 +80,7 @@ jobs:
       - uses: actions/cache@v2.1.5
         with:
           path: ~/.cache/pip
-          key: pip-${{ hashFiles('requirements.dev.txt') }}
+          key: pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             pip-
       - run: pip install -r worker/requirements.txt
@@ -125,7 +106,7 @@ jobs:
         run: npm run build-worker
         working-directory: ./backend
   deploy:
-    needs: [security, build_worker, lint, test, test_python]
+    needs: [build_worker, lint, test, test_python]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/production')
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,25 +21,6 @@ defaults:
     working-directory: ./frontend
 
 jobs:
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2.1.5
-        with:
-          node-version: '14'
-      - name: Restore npm cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Install dependencies
-        run: npm ci
-      - name: Security
-        run: npm audit
-        continue-on-error: true
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -80,7 +61,7 @@ jobs:
       - name: Test
         run: npm run test
   deploy:
-    needs: [security, lint, test]
+    needs: [lint, test]
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/production')
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron:  '0 1 * * *' # every day at 1 AM
   workflow_dispatch:
+  push:
+    - security
 
 jobs:
   backend:
@@ -69,6 +71,28 @@ jobs:
         run: npm ci
       - name: Security
         run: npm audit
+      # - name: Create issue
+      #   if: failure()
+      #   uses: imjohnbo/issue-bot@v3.0
+      #   with:
+      #     labels: "vulnerabilities, docs"
+      #     title: "Vulnerabilities found in docs"
+      #     body: |
+      #       ### Agenda
+
+      #       - [ ] Start the recording
+      #       - [ ] Check-ins
+      #       - [ ] Discussion points
+      #       - [ ] Post the recording
+                    
+      #       ### Discussion Points
+      #       Add things to discuss below
+
+      #       - [Work this week](https://github.com/orgs/github/projects/3)
+      #     pinned: false
+      #     close-previous: false
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   backend_python:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,90 @@
+name: Check for Vulnerabilities
+
+on:
+  schedule:
+    - cron:  '0 1 * * *' # every day at 1 AM
+  workflow_dispatch:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: '14'
+      - name: Restore npm cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Security
+        run: npm audit
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: '14'
+      - name: Restore npm cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Security
+        run: npm audit
+  docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: '14'
+      - name: Restore npm cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Security
+        run: npm audit
+  backend_python:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: 3.7
+      - uses: actions/cache@v2.1.5
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            pip-
+      - run: pip install safety
+      - run: safety check -r worker/requirements.txt


### PR DESCRIPTION
Add security pipeline to periodically check for vulnerabilities. Vulnerabilities shouldn't block deployment (as they could be false positives), and they shouldn't only be checked when we push code.

I think this PR strikes a good balance by checking for vulnerabilities periodically and making issues whenever they're found.

Also fixes https://github.com/cisagov/crossfeed/issues/1028 and fixes https://github.com/cisagov/crossfeed/issues/1117.