### PR TITLE
Optimize pip install with --no-cache-dir

### DIFF
--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -65,7 +65,7 @@ RUN echo 'cd /app/intrigue-ident && bundle exec ruby ./util/ident.rb $@' > /usr/
 # Python dependencies
 
 COPY worker/requirements.txt worker/requirements.txt
-RUN pip3 install -r worker/requirements.txt
+RUN pip3 install --no-cache-dir -r worker/requirements.txt
 
 COPY worker worker
 


### PR DESCRIPTION
Makes the worker dockerfile smaller. See https://stackoverflow.com/questions/45594707/what-is-pips-no-cache-dir-good-for
