### PR TITLE
Fix typo -> target-branch to target_branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         uses: crazy-max/ghaction-github-pages@v2.5.0
         with:
           keep_history: true
-          target-branch: gh-pages
+          target_branch: gh-pages
           build_dir: docs/public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We were getting some warnings / errors on the GH Pages workflow -- it should actually be target_branch: https://github.com/crazy-max/ghaction-github-pages