### PR TITLE
Use environments to secure deployments

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -105,10 +105,12 @@ jobs:
       - name: Build worker container
         run: npm run build-worker
         working-directory: ./backend
-  deploy:
+  deploy_staging:
     needs: [build_worker, lint, test, test_python]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/production')
+    environment: staging
+    concurrency: 1
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2.2.0
@@ -123,66 +125,80 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install dependencies
         run: npm ci
-      - name: Ensure domain exists - Staging
-        if: github.ref == 'refs/heads/master'
+      
+      - name: Ensure domain exists
         run: npx sls create_domain --stage=staging
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SLS_DEBUG: '*'
 
-      - name: Deploy backend - Staging
-        if: github.ref == 'refs/heads/master'
+      - name: Deploy backend
         run: npx sls deploy --stage=staging
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SLS_DEBUG: '*'
 
-      - name: Deploy worker - Staging
-        if: github.ref == 'refs/heads/master'
+      - name: Deploy worker
         run: npm run deploy-worker-staging
         working-directory: backend
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Run syncdb - Staging
-        if: github.ref == 'refs/heads/master'
+      - name: Run syncdb
         run: aws lambda invoke --function-name crossfeed-staging-syncdb --region us-east-1 /dev/stdout
         working-directory: backend
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Ensure domain exists - Production
-        if: github.ref == 'refs/heads/production'
+  deploy_prod:
+    needs: [build_worker, lint, test, test_python]
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency: 1
+    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.2.0
+        with:
+          node-version: '14'
+      - name: Restore npm cache
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Ensure domain exists
         run: npx sls create_domain --stage=prod
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SLS_DEBUG: '*'
 
-      - name: Deploy backend - Production
-        if: github.ref == 'refs/heads/production'
+      - name: Deploy backend
         run: npx sls deploy --stage=prod
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SLS_DEBUG: '*'
 
-      - name: Deploy worker - Production
-        if: github.ref == 'refs/heads/production'
+      - name: Deploy worker
         run: npm run deploy-worker-prod
         working-directory: backend
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Run syncdb - Production
-        if: github.ref == 'refs/heads/production'
+      - name: Run syncdb
         run: aws lambda invoke --function-name crossfeed-prod-syncdb --region us-east-1 /dev/stdout
         working-directory: backend
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -60,10 +60,12 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test
-  deploy:
+  deploy_staging:
     needs: [lint, test]
     runs-on: ubuntu-18.04
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/production')
+    environment: staging
+    concurrency: 1
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2.2.0
@@ -79,23 +81,40 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build Staging
-        if: github.ref == 'refs/heads/master'
         run: cp stage.env .env && npm run build
 
-      - name: Build Production
-        if: github.ref == 'refs/heads/production'
-        run: cp prod.env .env && npm run build
-
       - name: Deploy Staging
-        if: github.ref == 'refs/heads/master'
         run: aws s3 sync build s3://staging.crossfeed.cyber.dhs.gov --delete
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  deploy_prod:
+    needs: [lint, test]
+    runs-on: ubuntu-18.04
+    environment: production
+    concurrency: 1
+    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.2.0
+        with:
+          node-version: '14'
+      - name: Restore npm cache
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Production
+        run: cp prod.env .env && npm run build
 
       - name: Deploy Production
-        if: github.ref == 'refs/heads/production'
         run: aws s3 sync build s3://crossfeed.cyber.dhs.gov --delete
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -38,6 +38,8 @@ jobs:
   staging:
     timeout-minutes: 4320
     runs-on: ubuntu-latest
+    environment: staging
+    concurrency: 1
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -50,8 +52,8 @@ jobs:
       - name: Terraform init
         run: terraform init -backend-config=stage.config
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Terraform validation
         run: terraform validate
@@ -59,15 +61,15 @@ jobs:
       - name: Terraform plan
         run: terraform plan -var-file=stage.tfvars -out stage.plan
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Terraform apply
         if: github.ref == 'refs/heads/master'
         run: terraform apply stage.plan
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       
       - if: ${{ always() }}
         run: rm stage.plan || true
@@ -75,6 +77,8 @@ jobs:
   prod:
     timeout-minutes: 4320
     runs-on: ubuntu-latest
+    environment: production
+    concurrency: 1
     steps:
       - uses: actions/checkout@v2.3.4
 
@@ -87,27 +91,27 @@ jobs:
       - name: Terraform init
         run: terraform init -backend-config=prod.config -input=false
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Terraform validation
         run: terraform validate
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Terraform plan
         run: terraform plan -var-file=prod.tfvars -out prod.plan
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Terraform apply
         if: github.ref == 'refs/heads/production'
         run: terraform apply prod.plan
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       
       - if: ${{ always() }}
         run: rm prod.plan || true

--- a/docs/src/documentation-pages/dev/deployment.md
+++ b/docs/src/documentation-pages/dev/deployment.md
@@ -9,6 +9,8 @@ Deployment of CISA Crossfeed is done automatically through GitHub Actions from t
 
 Any code pushed to the `master` branch is automatically deployed to the [staging site](https://staging.crossfeed.cyber.dhs.gov/), and any code pushed to the `production` branch is automatically deployed to the [production site](https://crossfeed.cyber.dhs.gov/).
 
+[Environments](https://docs.github.com/en/actions/reference/environments) are configured to ensure that only specific users with the appropriate permissions can trigger workflows on GitHub Actions or access secrets that perform deployments. At the moment, GitHub Actions jobs that deploy to staging and prod or access credentials for those AWS environments must be [manually approved](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments).
+
 #### Setting up automatic deployment
 
 To set up automatic deployment to your own AWS environment, you must first create an IAM user with enough permissions to the right resources on AWS. Then, set the GitHub repository's secrets `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` to the access credentials of this user.


### PR DESCRIPTION
In this PR, [environments](https://docs.github.com/en/actions/reference/environments) are configured to ensure that only specific users with the appropriate permissions can trigger workflows on GitHub Actions or access secrets that perform deployments. At the moment, GitHub Actions jobs that deploy to staging and prod or access credentials for those AWS environments must be [manually approved](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) by me. Fixes https://github.com/cisagov/crossfeed/issues/1155.

The AWS access secrets are only accessible for workflows that specify an environment (`staging` or `prod`), and these workflows have also been set to have a concurrency of 1 (so we don't have multiple deployments at the same time). I've also renamed the secrets from AWS_ACCESS_KEY -> AWS_ACCESS_KEY_ID and AWS_SECRET_KEY -> AWS_SECRET_ACCESS_KEY for consistency.