### PR TITLE
Add link to setting up your own instance

### DIFF
--- a/docs/src/components/sidenav.js
+++ b/docs/src/components/sidenav.js
@@ -20,6 +20,7 @@ const SIDENAV_ITEMS = {
     { text: 'Search', link: '/dev/search/' },
     { text: 'Analytics', link: '/dev/analytics/' },
     { text: 'Deployment', link: '/dev/deployment/' },
+    { text: 'Setting up your own instance', link: '/dev/own-instance/' },
     { text: 'Contribution Guidelines', link: '/dev/guidelines/' },
   ],
   'user-guide': [


### PR DESCRIPTION
Added a link to https://docs.crossfeed.cyber.dhs.gov/dev/own-instance/ to the docs menu sidebar, which was mistakenly not added earlier.