### PR TITLE
Reduce Padding on Search Results Page to Reflect Design

### DIFF
--- a/frontend/src/pages/Search/ResultCard.tsx
+++ b/frontend/src/pages/Search/ResultCard.tsx
@@ -235,7 +235,7 @@ const useStyles = makeStyles((theme) => ({
     }
   },
   inner: {
-    padding: '1.5rem',
+    padding: '0.875rem',
     cursor: 'pointer'
   },
   domainRow: {

--- a/frontend/src/pages/Search/ResultCard.tsx
+++ b/frontend/src/pages/Search/ResultCard.tsx
@@ -235,7 +235,8 @@ const useStyles = makeStyles((theme) => ({
     }
   },
   inner: {
-    padding: '0.875rem',
+    padding: '1.5rem',
+    paddingTop: '0.875rem',
     cursor: 'pointer'
   },
   domainRow: {


### PR DESCRIPTION
Fixes #1090

Changed padding from 1.5 rem to .875 rem to make it 14px for the padding.

![image](https://user-images.githubusercontent.com/87027605/130272761-61a10dc0-6275-470e-b956-d01ff77cb734.png)
