### PR TITLE
Changed Export Results to a Button

### DIFF
--- a/frontend/src/pages/Search/Dashboard.tsx
+++ b/frontend/src/pages/Search/Dashboard.tsx
@@ -521,6 +521,9 @@ const useStyles = makeStyles(() => ({
   },
   exportButton: {
     justifyContent: 'flex-end',
+    backgroundColor: 'transparent',
+    color: '#005ea2',
+    boxShadow: '0 0 0 2px #005ea2',
     marginLeft: 'auto'
   },
   pageSize: {


### PR DESCRIPTION
Fixes issue #D6

Made the Export Results look like a button.

![image](https://user-images.githubusercontent.com/87027605/130290656-277ecdce-9b09-4cb5-b6f4-39613996f39b.png)
