### PR TITLE
Adjusted Shadow on Footer to match design

### DIFF
--- a/frontend/src/pages/Search/Dashboard.tsx
+++ b/frontend/src/pages/Search/Dashboard.tsx
@@ -509,6 +509,7 @@ const useStyles = makeStyles(() => ({
     flexFlow: 'row nowrap',
     justifyContent: 'flex-start',
     alignItems: 'center',
+    boxShadow: '0px -1px 2px rgba(0, 0, 0, 0.15)',
     padding: '1rem 2rem',
     '& > span': {
       marginRight: '2rem'


### PR DESCRIPTION
Fixes #1093

Adjusted the shadow on the Footer to match the design prototype.

![image](https://user-images.githubusercontent.com/87027605/131891331-ac3cb318-e895-4fa6-b261-2d6f4b572eb1.png)


