### PR TITLE
Add scan to import dotgov domains

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -130,7 +130,7 @@ export const SCAN_SCHEMA: ScanSchema = {
     isPassive: true,
     global: true,
     description:
-      'Create organizations based on root domains from the dotgov registrar dataset'
+      'Create organizations based on root domains from the dotgov registrar dataset. All organizations are created with the "dotgov" tag and have a " (dotgov)" suffix added to their name.'
   },
   searchSync: {
     type: 'fargate',

--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -125,6 +125,13 @@ export const SCAN_SCHEMA: ScanSchema = {
     memory: '8192',
     description: 'Matches detected software versions to CVEs from NIST NVD'
   },
+  dotgov: {
+    type: 'fargate',
+    isPassive: true,
+    global: true,
+    description:
+      'Create organizations based on root domains from the dotgov registrar dataset'
+  },
   searchSync: {
     type: 'fargate',
     isPassive: true,

--- a/backend/src/tasks/dotgov.ts
+++ b/backend/src/tasks/dotgov.ts
@@ -4,64 +4,72 @@ import axios from 'axios';
 import * as Papa from 'papaparse';
 
 interface ParsedRow {
-    "Domain Name": string;
-    "Domain Type": string;
-    "Agency": string;
-    "Organization": string;
-    "City": string;
-    "State": string;
-    "Security Contact Email": string;
+  'Domain Name': string;
+  'Domain Type': string;
+  Agency: string;
+  Organization: string;
+  City: string;
+  State: string;
+  'Security Contact Email': string;
 }
 
-export const DOTGOV_LIST_ENDPOINT = 'https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv';
+export const DOTGOV_LIST_ENDPOINT =
+  'https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv';
 export const DOTGOV_TAG_NAME = 'dotgov';
 
 export const handler = async (commandOptions: CommandOptions) => {
+  const { data } = await axios.get(DOTGOV_LIST_ENDPOINT);
+  const parsedRows: ParsedRow[] = await new Promise((resolve, reject) =>
+    Papa.parse(data, {
+      header: true,
+      dynamicTyping: true,
+      complete: ({ data, errors }) =>
+        errors.length ? reject(errors) : resolve(data as ParsedRow[])
+    })
+  );
 
-    const { data } = await axios.get(DOTGOV_LIST_ENDPOINT);
-    const parsedRows: ParsedRow[] = await new Promise((resolve, reject) =>
-        Papa.parse(data, {
-            header: true,
-            dynamicTyping: true,
-            complete: ({ data, errors }) =>
-                errors.length ? reject(errors) : resolve(data as ParsedRow[])
-        })
+  await connectToDatabase();
+
+  const orgsToRootDomainMap: {
+    [x: string]: { row: ParsedRow; rootDomains: Set<string> };
+  } = {};
+  for (const row of parsedRows) {
+    if (!orgsToRootDomainMap[row.Agency]) {
+      orgsToRootDomainMap[row.Agency] = { row, rootDomains: new Set() };
+    }
+    orgsToRootDomainMap[row.Agency].rootDomains.add(
+      row['Domain Name'].toLowerCase()
     );
+  }
 
-    await connectToDatabase();
+  const tag =
+    (await OrganizationTag.findOne({ where: { name: DOTGOV_TAG_NAME } })) ||
+    (await OrganizationTag.create({
+      name: DOTGOV_TAG_NAME
+    }).save());
 
-    const orgsToRootDomainMap: { [x: string]: { row: ParsedRow, rootDomains: Set<string> } } = {};
-    for (const row of parsedRows) {
-        if (!orgsToRootDomainMap[row.Agency]) {
-            orgsToRootDomainMap[row.Agency] = { row, rootDomains: new Set() };
-        }
-        orgsToRootDomainMap[row.Agency].rootDomains.add(row['Domain Name'].toLowerCase());
-    }
+  for (const [orgName, { row, rootDomains }] of Object.entries(
+    orgsToRootDomainMap
+  )) {
+    // Create a new organization if needed; else, create the same one.
+    const organization =
+      (await Organization.createQueryBuilder('organization')
+        .innerJoinAndSelect('organization.tags', 'tags')
+        .where('organization.name = :orgName', { orgName })
+        .andWhere('tags.id = :tagId', { tagId: tag.id })
+        .getOne()) ||
+      (await Organization.create({
+        name: orgName,
+        tags: [tag],
+        ipBlocks: [],
+        isPassive: true,
+        rootDomains: []
+      }));
+    // Replace existing rootDomains with new rootDomains.
+    organization.rootDomains = [...rootDomains];
+    await organization.save();
+    console.log('Finished org', orgName);
+  }
 
-    const tag = await OrganizationTag.findOne({ where: { name: DOTGOV_TAG_NAME } }) || await OrganizationTag.create({
-        name: DOTGOV_TAG_NAME,
-    }).save();
-
-    for (const [orgName, { row, rootDomains }] of Object.entries(orgsToRootDomainMap)) {
-        // Create a new organization if needed; else, create the same one.
-        console.log(orgName);
-        const organization = await Organization.findOne({
-            where: {
-                name: orgName,
-                tags: {
-                    name: tag
-                }
-            },
-            relations: ['tags']
-        }) || await Organization.create({
-            name: orgName,
-            // tags: [tag]
-        });
-        // Add rootDomains onto existing rootDomains.
-        organization.rootDomains = [...new Set([...organization.rootDomains, ...rootDomains])];
-        await organization.save();
-        console.log("Finished org", orgName);
-    }
-
-    console.log(`dotgov done`);
+  console.log(`dotgov done`);
 };

--- a/backend/src/tasks/dotgov.ts
+++ b/backend/src/tasks/dotgov.ts
@@ -1,0 +1,67 @@
+import { connectToDatabase, Organization, OrganizationTag } from '../models';
+import { CommandOptions } from './ecs-client';
+import axios from 'axios';
+import * as Papa from 'papaparse';
+
+interface ParsedRow {
+    "Domain Name": string;
+    "Domain Type": string;
+    "Agency": string;
+    "Organization": string;
+    "City": string;
+    "State": string;
+    "Security Contact Email": string;
+}
+
+export const DOTGOV_LIST_ENDPOINT = 'https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv';
+export const DOTGOV_TAG_NAME = 'dotgov';
+
+export const handler = async (commandOptions: CommandOptions) => {
+
+    const { data } = await axios.get(DOTGOV_LIST_ENDPOINT);
+    const parsedRows: ParsedRow[] = await new Promise((resolve, reject) =>
+        Papa.parse(data, {
+            header: true,
+            dynamicTyping: true,
+            complete: ({ data, errors }) =>
+                errors.length ? reject(errors) : resolve(data as ParsedRow[])
+        })
+    );
+
+    await connectToDatabase();
+
+    const orgsToRootDomainMap: { [x: string]: { row: ParsedRow, rootDomains: Set<string> } } = {};
+    for (const row of parsedRows) {
+        if (!orgsToRootDomainMap[row.Agency]) {
+            orgsToRootDomainMap[row.Agency] = { row, rootDomains: new Set() };
+        }
+        orgsToRootDomainMap[row.Agency].rootDomains.add(row['Domain Name'].toLowerCase());
+    }
+
+    const tag = await OrganizationTag.findOne({ where: { name: DOTGOV_TAG_NAME } }) || await OrganizationTag.create({
+        name: DOTGOV_TAG_NAME,
+    }).save();
+
+    for (const [orgName, { row, rootDomains }] of Object.entries(orgsToRootDomainMap)) {
+        // Create a new organization if needed; else, create the same one.
+        console.log(orgName);
+        const organization = await Organization.findOne({
+            where: {
+                name: orgName,
+                tags: {
+                    name: tag
+                }
+            },
+            relations: ['tags']
+        }) || await Organization.create({
+            name: orgName,
+            // tags: [tag]
+        });
+        // Add rootDomains onto existing rootDomains.
+        organization.rootDomains = [...new Set([...organization.rootDomains, ...rootDomains])];
+        await organization.save();
+        console.log("Finished org", orgName);
+    }
+
+    console.log(`dotgov done`);
+};

--- a/backend/src/tasks/test/__snapshots__/dotgov.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/dotgov.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dotgov basic test 1`] = `
+Array [
+  Object {
+    "name": "Administrative Conference of the United States",
+    "rootDomains": Array [
+      "acus.gov",
+    ],
+  },
+  Object {
+    "name": "Advisory Council on Historic Preservation",
+    "rootDomains": Array [
+      "achp.gov",
+      "preserveamerica.gov",
+    ],
+  },
+  Object {
+    "name": "American Battle Monuments Commission",
+    "rootDomains": Array [
+      "abmc.gov",
+      "abmcscholar.gov",
+      "nationalmall.gov",
+    ],
+  },
+  Object {
+    "name": "AMTRAK",
+    "rootDomains": Array [
+      "amtrakoig.gov",
+    ],
+  },
+  Object {
+    "name": "Appalachian Regional Commission",
+    "rootDomains": Array [
+      "arc.gov",
+    ],
+  },
+  Object {
+    "name": "Appraisal Subcommittee",
+    "rootDomains": Array [
+      "asc.gov",
+    ],
+  },
+  Object {
+    "name": "Armed Forces Retirement Home",
+    "rootDomains": Array [
+      "afrh.gov",
+    ],
+  },
+  Object {
+    "name": "Barry Goldwater Scholarship and Excellence in Education Foundation",
+    "rootDomains": Array [
+      "goldwaterscholarship.gov",
+    ],
+  },
+]
+`;

--- a/backend/src/tasks/test/__snapshots__/dotgov.test.ts.snap
+++ b/backend/src/tasks/test/__snapshots__/dotgov.test.ts.snap
@@ -3,20 +3,20 @@
 exports[`dotgov basic test 1`] = `
 Array [
   Object {
-    "name": "Administrative Conference of the United States",
+    "name": "Administrative Conference of the United States (dotgov)",
     "rootDomains": Array [
       "acus.gov",
     ],
   },
   Object {
-    "name": "Advisory Council on Historic Preservation",
+    "name": "Advisory Council on Historic Preservation (dotgov)",
     "rootDomains": Array [
       "achp.gov",
       "preserveamerica.gov",
     ],
   },
   Object {
-    "name": "American Battle Monuments Commission",
+    "name": "American Battle Monuments Commission (dotgov)",
     "rootDomains": Array [
       "abmc.gov",
       "abmcscholar.gov",
@@ -24,31 +24,31 @@ Array [
     ],
   },
   Object {
-    "name": "AMTRAK",
+    "name": "AMTRAK (dotgov)",
     "rootDomains": Array [
       "amtrakoig.gov",
     ],
   },
   Object {
-    "name": "Appalachian Regional Commission",
+    "name": "Appalachian Regional Commission (dotgov)",
     "rootDomains": Array [
       "arc.gov",
     ],
   },
   Object {
-    "name": "Appraisal Subcommittee",
+    "name": "Appraisal Subcommittee (dotgov)",
     "rootDomains": Array [
       "asc.gov",
     ],
   },
   Object {
-    "name": "Armed Forces Retirement Home",
+    "name": "Armed Forces Retirement Home (dotgov)",
     "rootDomains": Array [
       "afrh.gov",
     ],
   },
   Object {
-    "name": "Barry Goldwater Scholarship and Excellence in Education Foundation",
+    "name": "Barry Goldwater Scholarship and Excellence in Education Foundation (dotgov)",
     "rootDomains": Array [
       "goldwaterscholarship.gov",
     ],

--- a/backend/src/tasks/test/dotgov.test.ts
+++ b/backend/src/tasks/test/dotgov.test.ts
@@ -1,6 +1,7 @@
 import {
   handler as dotgov,
   DOTGOV_TAG_NAME,
+  DOTGOV_ORG_SUFFIX,
   DOTGOV_LIST_ENDPOINT
 } from '../dotgov';
 import * as nock from 'nock';
@@ -11,7 +12,7 @@ import {
   OrganizationTag
 } from '../../models';
 
-const HOST = 'https://github.com';
+const HOST = 'https://raw.githubusercontent.com';
 const PATH = DOTGOV_LIST_ENDPOINT.replace(HOST, '');
 
 describe('dotgov', () => {
@@ -23,6 +24,12 @@ describe('dotgov', () => {
       arguments: {},
       frequency: 999
     }).save();
+    // Clean up any OrganizationTag / Organizations created from earlier tests
+    await OrganizationTag.delete({ name: DOTGOV_TAG_NAME });
+    await Organization.createQueryBuilder('organization')
+      .where('name like :name', { name: `%${DOTGOV_ORG_SUFFIX}%` })
+      .delete()
+      .execute();
   });
 
   test('basic test', async () => {
@@ -42,7 +49,6 @@ AFRH.GOV,Federal Agency - Executive,Armed Forces Retirement Home,Armed Forces Re
 GOLDWATERSCHOLARSHIP.GOV,Federal Agency - Executive,Barry Goldwater Scholarship and Excellence in Education Foundation,Barry Goldwater Scholarship and Excellence in Education Foundation,Alexandria,VA,goldwaterao@goldwaterscholarship.gov`
     );
 
-    await OrganizationTag.delete({ name: DOTGOV_TAG_NAME });
     await dotgov({
       organizationId: 'organizationId',
       organizationName: 'organizationName',
@@ -76,7 +82,6 @@ site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.g
 site2.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,domainsecurity@achp.gov`
     );
 
-    await OrganizationTag.delete({ name: DOTGOV_TAG_NAME });
     await dotgov({
       organizationId: 'organizationId',
       organizationName: 'organizationName',
@@ -96,7 +101,7 @@ site2.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,domainsecur
       .getMany();
 
     expect(organizations.length).toEqual(1);
-    expect(organizations[0].name).toEqual('Agency 1');
+    expect(organizations[0].name).toEqual('Agency 1 (dotgov)');
     expect(organizations[0].rootDomains).toEqual(['site1.gov', 'site2.gov']);
   });
 
@@ -106,8 +111,6 @@ site2.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,domainsecur
       `Domain Name,Domain Type,Agency,Organization,City,State,Security Contact Email
 site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.gov`
     );
-
-    await OrganizationTag.delete({ name: DOTGOV_TAG_NAME });
 
     const originalOrganization = await Organization.create({
       name: 'Agency 1',
@@ -134,7 +137,7 @@ site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.g
       .getMany();
 
     expect(organizations.length).toEqual(1);
-    expect(organizations[0].name).toEqual('Agency 1');
+    expect(organizations[0].name).toEqual('Agency 1 (dotgov)');
     expect(organizations[0].rootDomains).toEqual(['site1.gov']);
     expect(organizations[0].id).not.toEqual(originalOrganization.id);
   });
@@ -146,7 +149,6 @@ site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.g
 site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.gov`
     );
 
-    await OrganizationTag.delete({ name: DOTGOV_TAG_NAME });
     const originalTag = await OrganizationTag.create({
       name: DOTGOV_TAG_NAME
     }).save();
@@ -171,7 +173,7 @@ site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.g
       .getMany();
 
     expect(organizations.length).toEqual(1);
-    expect(organizations[0].name).toEqual('Agency 1');
+    expect(organizations[0].name).toEqual('Agency 1 (dotgov)');
     expect(organizations[0].rootDomains).toEqual(['site1.gov']);
   });
 
@@ -182,13 +184,12 @@ site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.g
 site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.gov`
     );
 
-    await OrganizationTag.delete({ name: DOTGOV_TAG_NAME });
     const tag = await OrganizationTag.create({
       name: DOTGOV_TAG_NAME
     }).save();
 
     const originalOrganization = await Organization.create({
-      name: 'Agency 1',
+      name: 'Agency 1 (dotgov)',
       ipBlocks: [],
       tags: [tag],
       isPassive: false,
@@ -208,7 +209,7 @@ site1.gov,Federal Agency - Executive,Agency 1,Agency 1,Washington,DC,info@acus.g
       .getMany();
 
     expect(organizations.length).toEqual(1);
-    expect(organizations[0].name).toEqual('Agency 1');
+    expect(organizations[0].name).toEqual('Agency 1 (dotgov)');
     expect(organizations[0].rootDomains).toEqual(['site1.gov']);
     expect(organizations[0].id).toEqual(originalOrganization.id);
     expect(organizations[0].isPassive).toEqual(false);

--- a/backend/src/tasks/test/dotgov.test.ts
+++ b/backend/src/tasks/test/dotgov.test.ts
@@ -1,0 +1,58 @@
+import { handler as dotgov, DOTGOV_TAG_NAME } from '../dotgov';
+import * as nock from 'nock';
+import { connectToDatabase, Scan, Organization, OrganizationTag } from '../../models';
+
+
+describe('dotgov', () => {
+  let scan;
+  beforeEach(async () => {
+    await connectToDatabase();
+    scan = await Scan.create({
+      name: 'censysIpv4',
+      arguments: {},
+      frequency: 999
+    }).save();
+  });
+
+  test('basic test', async () => {
+    nock('https://github.com')
+      .get('/cisagov/dotgov-data/blob/main/current-federal.csv')
+      .reply(200, `Domain Name,Domain Type,Agency,Organization,City,State,Security Contact Email
+ACUS.GOV,Federal Agency - Executive,Administrative Conference of the United States,ADMINISTRATIVE CONFERENCE OF THE UNITED STATES,Washington,DC,info@acus.gov
+ACHP.GOV,Federal Agency - Executive,Advisory Council on Historic Preservation,ACHP,Washington,DC,domainsecurity@achp.gov
+PRESERVEAMERICA.GOV,Federal Agency - Executive,Advisory Council on Historic Preservation,ACHP,Washington,DC,domainsecurity@achp.gov
+ABMC.GOV,Federal Agency - Executive,American Battle Monuments Commission,American Battle Monuments Commission,Arlington,VA,itsec@abmc.gov
+ABMCSCHOLAR.GOV,Federal Agency - Executive,American Battle Monuments Commission,Office of Chief Information Officer,Arlington,VA,itsec@abmc.gov
+NATIONALMALL.GOV,Federal Agency - Executive,American Battle Monuments Commission,Office of Chief Information Officer,Arlington,VA,itsec@abmc.gov
+AMTRAKOIG.GOV,Federal Agency - Executive,AMTRAK,Amtrak Office of Inspector General,Washington,DC,(blank)
+ARC.GOV,Federal Agency - Executive,Appalachian Regional Commission,ARC,Washington,DC,(blank)
+ASC.GOV,Federal Agency - Executive,Appraisal Subcommittee,Appraisal Subcommittee,Washington,DC,(blank)
+AFRH.GOV,Federal Agency - Executive,Armed Forces Retirement Home,Armed Forces Retirement Home,Washington,DC,Stanley.Whitehead@afrh.gov
+GOLDWATERSCHOLARSHIP.GOV,Federal Agency - Executive,Barry Goldwater Scholarship and Excellence in Education Foundation,Barry Goldwater Scholarship and Excellence in Education Foundation,Alexandria,VA,goldwaterao@goldwaterscholarship.gov`
+      );
+
+    await OrganizationTag.delete({name: DOTGOV_TAG_NAME});
+    await dotgov({
+      organizationId: 'organizationId',
+      organizationName: 'organizationName',
+      scanId: scan.id,
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+
+    const tag = await OrganizationTag.findOne({where: {name: DOTGOV_TAG_NAME}});
+    expect(tag).toBeTruthy();
+
+    const organizations = await Organization.find({
+        where: {
+            tags: {
+                name: tag
+            }
+        },
+        relations: ['tags']
+    })
+    expect(organizations).toEqual([]);
+
+    // await checkDomains(organization);
+  });
+});

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -12,6 +12,7 @@ import { handler as sslyze } from './tasks/sslyze';
 import { handler as searchSync } from './tasks/search-sync';
 import { handler as intrigueIdent } from './tasks/intrigue-ident';
 import { handler as cve } from './tasks/cve';
+import { handler as dotgov } from './tasks/dotgov';
 import { handler as webscraper } from './tasks/webscraper';
 import { handler as shodan } from './tasks/shodan';
 import { handler as testProxy } from './tasks/test-proxy';
@@ -40,6 +41,7 @@ async function main() {
     sslyze,
     searchSync,
     cve,
+    dotgov,
     findomain,
     portscanner,
     wappalyzer,

--- a/frontend/src/pages/Scans/ScanTasksView.tsx
+++ b/frontend/src/pages/Scans/ScanTasksView.tsx
@@ -174,6 +174,7 @@ export const ScanTasksView: React.FC = () => {
         'sslyze',
         'searchSync',
         'cve',
+        'dotgov',
         'webscraper',
         'intrigueIdent',
         'shodan',


### PR DESCRIPTION
## 🗣 Description ##

Add scan to import dotgov domains (from https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv).

The scan creates organizations based on root domains from the dotgov registrar dataset. All organizations are created with the "dotgov" tag and have a " (dotgov)" suffix added to their name.