### PR TITLE
Add export bucket expiration

### DIFF
--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -298,4 +298,12 @@ resource "aws_s3_bucket" "export_bucket" {
     Project = var.project
     Stage   = var.stage
   }
+  
+  lifecycle_rule {
+    id = "all_files"
+    enabled = true
+    expiration {
+      days = 1
+    }
+  }
 }

--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -298,9 +298,9 @@ resource "aws_s3_bucket" "export_bucket" {
     Project = var.project
     Stage   = var.stage
   }
-  
+
   lifecycle_rule {
-    id = "all_files"
+    id      = "all_files"
     enabled = true
     expiration {
       days = 1


### PR DESCRIPTION
## 🗣 Description ##

Adds a lifecycle rule to the export bucket to automatically delete objects after 1 day.

## 💭 Motivation and context ##

Eliminates unnecessary storage/security risks as exported files don't need to be saved after they are downloaded.