### PR TITLE
Fix and clarify test-proxy scan instructions

### DIFF
--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -49,6 +49,12 @@ interface ScanSchema {
 }
 
 export const SCAN_SCHEMA: ScanSchema = {
+  testProxy: {
+    type: 'fargate',
+    isPassive: false,
+    global: true,
+    description: 'Not a real scan, used to test proxy'
+  },
   censys: {
     type: 'fargate',
     isPassive: true,

--- a/backend/src/tasks/test-proxy.ts
+++ b/backend/src/tasks/test-proxy.ts
@@ -18,8 +18,11 @@ const WEBSCRAPER_DIRECTORY = '/app/worker/webscraper';
  * which require proxy integration (such as adding code in a
  * new language). If a new scan / tool is added, you may need to add
  * additional lines of code to this scan so that it tests
- * that tool out.
- *
+ * that tool out. Here are examples of PRs for which you should run
+ * this scan before merging:
+ * * Bump mitmproxy from 6.0.2 to 7.0.3 https://github.com/cisagov/crossfeed/pull/1193
+ * * Add webscraper scan https://github.com/cisagov/crossfeed/pull/517
+ * 
  * To run the test, first go to https://webhook.site/, create a new webhook URL,
  * and replace the WEBHOOK_URL_HTTPS and WEBHOOK_ADMIN_URL constants accordingly.
  * Then run:

--- a/backend/src/tasks/test-proxy.ts
+++ b/backend/src/tasks/test-proxy.ts
@@ -3,29 +3,34 @@ import { CommandOptions } from './ecs-client';
 import { spawnSync } from 'child_process';
 import { writeFileSync } from 'fs';
 
-const WEBHOOK_URL_HTTP =
-  'http://webhook.site/0f3e7e8f-ffe4-46df-aad1-d017b2c27921';
 const WEBHOOK_URL_HTTPS =
-  'https://webhook.site/0f3e7e8f-ffe4-46df-aad1-d017b2c27921';
+  'https://webhook.site/fef89312-ab36-46fc-bb9b-8a9943f01e55';
 const WEBHOOK_ADMIN_URL =
   'https://webhook.site/#!/0f3e7e8f-ffe4-46df-aad1-d017b2c27921';
+const WEBHOOK_URL_HTTP = WEBHOOK_URL_HTTPS.replace('https://', 'http://');
 
 const WEBSCRAPER_DIRECTORY = '/app/worker/webscraper';
 
 /**
  * Integration test to make sure that the proxies work properly.
- * This test should be run manually whenever dependencies are upgraded, etc.
+ * This test should be run manually whenever worker dependencies
+ * that might affect the proxy are upgraded or new scans are added
+ * which require proxy integration (such as adding code in a
+ * new language).
+ *
+ *
+ * To run the test, first go to https://webhook.site/, create a new webhook URL,
+ * and replace the WEBHOOK_URL_HTTPS and WEBHOOK_ADMIN_URL constants accordingly.
+ * Then run:
+ * npm start (from the root directory)
+ * cd backend && npm run build-worker && docker run -e WORKER_TEST=true -e ELASTICSEARCH_ENDPOINT=http://es:9200 --network="crossfeed_backend" -t crossfeed-worker
  *
  * Results should be checked at WEBHOOK_ADMIN_URL. All the requests made below
  * should display at the admin URL, and they should all be signed and have a
  * Crossfeed test user agent.
  *
- * To run the test, run:
- * npm start (from the root directory)
- * cd backend && docker run -e WORKER_TEST=true --network="crossfeed_backend" -t crossfeed-worker
- *
- * In the future, we can point these URLs to a locally running web server
- * in order to make this test be able to be automatically run.
+ * TODO: Point these URLs to a locally running web server
+ * in order to make this test be able to be automatically run on CI.
  */
 export const handler = async (commandOptions: CommandOptions) => {
   await axios.get(WEBHOOK_URL_HTTP + '?source=axios');

--- a/backend/src/tasks/test-proxy.ts
+++ b/backend/src/tasks/test-proxy.ts
@@ -16,8 +16,9 @@ const WEBSCRAPER_DIRECTORY = '/app/worker/webscraper';
  * This test should be run manually whenever worker dependencies
  * that might affect the proxy are upgraded or new scans are added
  * which require proxy integration (such as adding code in a
- * new language).
- *
+ * new language). If a new scan / tool is added, you may need to add
+ * additional lines of code to this scan so that it tests
+ * that tool out.
  *
  * To run the test, first go to https://webhook.site/, create a new webhook URL,
  * and replace the WEBHOOK_URL_HTTPS and WEBHOOK_ADMIN_URL constants accordingly.

--- a/backend/src/tasks/test-proxy.ts
+++ b/backend/src/tasks/test-proxy.ts
@@ -22,7 +22,7 @@ const WEBSCRAPER_DIRECTORY = '/app/worker/webscraper';
  * this scan before merging:
  * * Bump mitmproxy from 6.0.2 to 7.0.3 https://github.com/cisagov/crossfeed/pull/1193
  * * Add webscraper scan https://github.com/cisagov/crossfeed/pull/517
- * 
+ *
  * To run the test, first go to https://webhook.site/, create a new webhook URL,
  * and replace the WEBHOOK_URL_HTTPS and WEBHOOK_ADMIN_URL constants accordingly.
  * Then run:

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -30,7 +30,7 @@ async function main() {
   );
   console.log('commandOptions are', commandOptions);
 
-  const { scanName, organizations = [] } = commandOptions;
+  const { scanName = 'testProxy', organizations = [] } = commandOptions;
 
   const scanFn = {
     amass,
@@ -52,7 +52,7 @@ async function main() {
     dnstwist,
     testProxy,
     rootDomainSync
-  }[scanName || 'testProxy'];
+  }[scanName];
   if (!scanFn) {
     throw new Error('Invalid scan name ' + scanName);
   }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

Fix and clarify test-proxy scan instructions. This scan is used to test the proxy (which adds in the user-agent and signs all requests from Crossfeed) and is only run locally on the command line.

Clarify how to set up and check the webhook URL, and also fix some bugs that were making the test-proxy scan fail earlier.