### PR TITLE
Enable local build on ARM64

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,8 +3,8 @@ FROM node:14-buster-slim
 WORKDIR /app
 COPY ./package* ./
 
-RUN apt-get update
-RUN apt-get -y install chromium
+RUN apt-get update && apt-get -y install chromium && \
+    rm -rf /var/lib/apt/lists/*
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 RUN npm ci

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,10 @@ FROM node:14-buster-slim
 WORKDIR /app
 COPY ./package* ./
 
+RUN apt-get update
+RUN apt-get -y install chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 RUN npm ci
 
 COPY . .

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -3,8 +3,8 @@ FROM node:14-buster-slim as build
 WORKDIR /app
 
 COPY ./package* ./
-RUN apt-get update
-RUN apt-get -y install chromium
+RUN apt-get update && apt-get -y install chromium && \
+    rm -rf /var/lib/apt/lists/*
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 RUN npm ci

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -3,7 +3,10 @@ FROM node:14-buster-slim as build
 WORKDIR /app
 
 COPY ./package* ./
-
+RUN apt-get update
+RUN apt-get -y install chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 RUN npm ci
 
 COPY tsconfig.json ./tsconfig.json

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,13 +1,14 @@
 # This file is built with Docker context in the main directory (not ./docs)
 # so that ./backend is accessible.
 
-FROM node:14-buster-slim
+FROM node:14-bullseye-slim
 
 WORKDIR /app/docs
 
 RUN apt-get update && apt-get install -y \
     libvips-dev \
     glib2.0-dev \
+    build-essential \
  && rm -rf /var/lib/apt/lists/*
 
 COPY ./docs/package* ./


### PR DESCRIPTION
resolves #1197 

## 🗣 Description ##
Allow local build of the backend, backend worker, and docs.

## 💭 Motivation and context ##
As described in #1197, crossfeed has not supported local build on Arm64 including Apple Silicon M1.
This may put future contributors in trouble because Apple has decided not to build a new Mac based on Intel chips.
Specifically, the backend needs to support chromium-browser while Puppeteer does the scrapings.

## 🧪 Testing ##
I tested with `npm run build-worker` and `npm start` for the purpose of checking successful builds.
The environment is `Darwin xxxx 20.6.0 Darwin Kernel Version 20.6.0: Mon Aug 30 06:12:20 PDT 2021; root:xnu-7195.141.6~3/RELEASE_ARM64_T8101 arm64`. 
The problem is that `npm start` actually builds and starts the services; however, it actually fails during the run-time.
Particularly, I came across #1118. 

*edit* I tested with `x86_64`, but it seems the local development servers fail regardless of OS architecture.

## 📷 Screenshots (if appropriate) ##

## ✅ Checklist ##


- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
