### PR TITLE
Fixed Login Styling Issue

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -70,3 +70,7 @@ body {
   --amplify-font-family: 'Source Sans Pro Web', 'Helvetica Neue', Helvetica,
     Roboto, Arial, sans-serif;
 }
+
+amplify-authenticator {
+  --container-height: 100%;
+}


### PR DESCRIPTION
Found the solution here:
https://github.com/aws-amplify/amplify-js/discussions/7820

fixes #1309 

Login screen now looks like it did before
![Screen Shot 2021-11-12 at 5 05 42 PM](https://user-images.githubusercontent.com/79927030/141540141-7e1ee289-0c60-485e-b6e0-0fa44ccbd1d0.png)
:
