### PR TITLE
Add `isUserModifiable` option for scans

### DIFF
--- a/backend/src/api/organizations.ts
+++ b/backend/src/api/organizations.ts
@@ -304,7 +304,7 @@ class UpdateBody {
  *
  * /organizations/{id}/granularScans/{scanId}/update:
  *  post:
- *    description: Enable or disable a scan for a particular organization.
+ *    description: Enable or disable a scan for a particular organization; this endpoint can be called by organization admins and only works for user-modifiable scans.
  *    parameters:
  *      - in: path
  *        name: id
@@ -332,7 +332,8 @@ export const updateScan = wrapHandler(async (event) => {
   }
   const scan = await Scan.findOne({
     id: scanId,
-    isGranular: true
+    isGranular: true,
+    isUserModifiable: true
   });
   const organization = await Organization.findOne(
     {

--- a/backend/src/api/scans.ts
+++ b/backend/src/api/scans.ts
@@ -216,6 +216,9 @@ class NewScan {
   isGranular: boolean;
 
   @IsBoolean()
+  isUserModifiable: boolean;
+
+  @IsBoolean()
   isSingleScan: boolean;
 
   @IsUUID('all', { each: true })
@@ -397,16 +400,17 @@ export const list = wrapHandler(async (event) => {
  *
  * /granularScans:
  *  get:
- *    description: List granular scans. These scans are retrieved by a standard organization admin user, who is then able to enable or disable these particular scans.
+ *    description: List user-modifiable scans. These scans are retrieved by a standard organization admin user, who is then able to enable or disable these particular scans.
  *    tags:
  *    - Scans
  */
 export const listGranular = wrapHandler(async (event) => {
   await connectToDatabase();
   const scans = await Scan.find({
-    select: ['id', 'name', 'isGranular'],
+    select: ['id', 'name', 'isUserModifiable'],
     where: {
       isGranular: true,
+      isUserModifiable: true,
       isSingleScan: false
     }
   });

--- a/backend/src/models/scan.ts
+++ b/backend/src/models/scan.ts
@@ -56,6 +56,17 @@ export class Scan extends BaseEntity {
   })
   isGranular: boolean;
 
+  /** Whether the scan is user-modifiable. User-modifiable
+   * scans are granular scans that can be viewed and toggled on/off by
+   * organization admins themselves.
+   */
+  @Column({
+    type: 'boolean',
+    default: false,
+    nullable: true
+  })
+  isUserModifiable: boolean;
+
   /**
    * If the scan is granular, specifies organizations that the
    * scan will run on.

--- a/backend/test/organizations.test.ts
+++ b/backend/test/organizations.test.ts
@@ -420,7 +420,7 @@ describe('organizations', () => {
     });
   });
   describe('update', () => {
-    it('enabling a scan by org admin for an organization should succeed', async () => {
+    it('enabling a user-modifiable scan by org admin for an organization should succeed', async () => {
       const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],
@@ -431,7 +431,8 @@ describe('organizations', () => {
         name: 'censys',
         arguments: {},
         frequency: 999999,
-        isGranular: true
+        isGranular: true,
+        isUserModifiable: true,
       }).save();
       const response = await request(app)
         .post(
@@ -465,7 +466,7 @@ describe('organizations', () => {
         ])
       );
     });
-    it('disabling a scan by org admin for an organization should succeed', async () => {
+    it('disabling a user-modifiable scan by org admin for an organization should succeed', async () => {
       const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],
@@ -477,7 +478,8 @@ describe('organizations', () => {
         arguments: {},
         frequency: 999999,
         organizations: [organization],
-        isGranular: true
+        isGranular: true,
+        isUserModifiable: true,
       }).save();
       const response = await request(app)
         .post(
@@ -504,17 +506,19 @@ describe('organizations', () => {
       expect(updated.name).toEqual(organization.name);
       expect(updated.granularScans).toEqual([]);
     });
-    it('enabling a scan by org user for an organization should fail', async () => {
+    it('enabling a user-modifiable scan by org user for an organization should fail', async () => {
       const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],
         ipBlocks: [],
-        isPassive: false
+        isPassive: false,
       }).save();
       const scan = await Scan.create({
         name: 'censys',
         arguments: {},
-        frequency: 999999
+        frequency: 999999,
+        isGranular: true,
+        isUserModifiable: true,
       }).save();
       const response = await request(app)
         .post(
@@ -531,7 +535,7 @@ describe('organizations', () => {
         })
         .expect(403);
     });
-    it('enabling a scan by globalAdmin for an organization should succeed', async () => {
+    it('enabling a user-modifiable scan by globalAdmin for an organization should succeed', async () => {
       const organization = await Organization.create({
         name: 'test-' + Math.random(),
         rootDomains: ['test-' + Math.random()],
@@ -542,7 +546,8 @@ describe('organizations', () => {
         name: 'censys',
         arguments: {},
         frequency: 999999,
-        isGranular: true
+        isGranular: true,
+        isUserModifiable: true,
       }).save();
       const response = await request(app)
         .post(
@@ -574,6 +579,34 @@ describe('organizations', () => {
           })
         ])
       );
+    });
+    it('enabling a non-user-modifiable scan by org admin for an organization should fail', async () => {
+      const organization = await Organization.create({
+        name: 'test-' + Math.random(),
+        rootDomains: ['test-' + Math.random()],
+        ipBlocks: [],
+        isPassive: false
+      }).save();
+      const scan = await Scan.create({
+        name: 'censys',
+        arguments: {},
+        frequency: 999999,
+        isGranular: true,
+      }).save();
+      const response = await request(app)
+        .post(
+          `/organizations/${organization.id}/granularScans/${scan.id}/update`
+        )
+        .set(
+          'Authorization',
+          createUserToken({
+            roles: [{ org: organization.id, role: 'admin' }]
+          })
+        )
+        .send({
+          enabled: true
+        })
+        .expect(403);
     });
   });
   describe('approveRole', () => {

--- a/backend/test/scans.test.ts
+++ b/backend/test/scans.test.ts
@@ -78,13 +78,14 @@ describe('scan', () => {
     // });
   });
   describe('listGranular', () => {
-    it('list by regular user should return all granular scans', async () => {
+    it('list by regular user should return all granular, user-modifiable scans', async () => {
       const name = 'test-' + Math.random();
       const scan1 = await Scan.create({
         name,
         arguments: {},
         frequency: 999999,
         isGranular: false,
+        isUserModifiable: false,
         isSingleScan: false
       }).save();
       const scan2 = await Scan.create({
@@ -92,6 +93,7 @@ describe('scan', () => {
         arguments: {},
         frequency: 999999,
         isGranular: true,
+        isUserModifiable: true,
         isSingleScan: false
       }).save();
       const response = await request(app)
@@ -113,6 +115,7 @@ describe('scan', () => {
         arguments: {},
         frequency: 999999,
         isGranular: true,
+        isUserModifiable: true,
         isSingleScan: false
       }).save();
       const scan2 = await Scan.create({

--- a/frontend/src/components/ScanForm/ScanForm.tsx
+++ b/frontend/src/components/ScanForm/ScanForm.tsx
@@ -21,6 +21,7 @@ export interface ScanFormValues {
   frequency: number;
   frequencyUnit: string;
   isGranular: boolean;
+  isUserModifiable: boolean;
   isSingleScan: boolean;
 }
 
@@ -49,6 +50,7 @@ export const ScanForm: React.FC<{
     frequency: scan ? scan.frequency : 1,
     frequencyUnit: scan ? propValues.frequencyUnit : 'minute',
     isGranular: scan ? scan.isGranular : false,
+    isUserModifiable: scan ? scan.isUserModifiable : false,
     isSingleScan: scan ? scan.isSingleScan : false,
     organizations: scan ? propValues.organizations : [],
     tags: scan ? propValues.tags : []
@@ -91,6 +93,7 @@ export const ScanForm: React.FC<{
           frequency: propValues.frequency,
           frequencyUnit: propValues.frequencyUnit,
           isGranular: scan.isGranular,
+          isUserModifiable: scan.isUserModifiable,
           isSingleScan: scan.isSingleScan,
           organizations: propValues.organizations,
           tags: propValues.tags
@@ -127,6 +130,7 @@ export const ScanForm: React.FC<{
           frequency: values.frequency,
           frequencyUnit: values.frequencyUnit,
           isGranular: values.isGranular,
+          isUserModifiable: values.isUserModifiable,
           isSingleScan: values.isSingleScan
         });
       }}
@@ -171,7 +175,13 @@ export const ScanForm: React.FC<{
           label="Limit enabled organizations"
           name="isGranular"
           checked={values.isGranular}
-          onChange={(e) => onChange('isGranular', e.target.checked)}
+          onChange={(e) => {
+            onChange('isGranular', e.target.checked);
+            if (!e.target.checked) {
+              // Only granular scans can be user-modifiable.
+              onChange('isUserModifiable', false);
+            }
+          }}
         />
       )}
       {values.isGranular && (
@@ -191,6 +201,18 @@ export const ScanForm: React.FC<{
             value={values.tags}
             onChange={(e) => onChange('tags', e)}
             zIndex={99}
+          />
+          <br />
+        </>
+      )}
+      {values.isGranular && (
+        <>
+          <Checkbox
+            id="isUserModifiable"
+            label="Allow organization admins to toggle this scan on/off"
+            name="isUserModifiable"
+            checked={values.isUserModifiable}
+            onChange={(e) => onChange('isUserModifiable', e.target.checked)}
           />
           <br />
         </>

--- a/frontend/src/pages/Scan/Scan.tsx
+++ b/frontend/src/pages/Scan/Scan.tsx
@@ -35,6 +35,7 @@ const ScanComponent: React.FC = () => {
     frequency: 1,
     frequencyUnit: 'minute',
     isGranular: false,
+    isUserModifiable: false,
     isSingleScan: false,
     tags: []
   });

--- a/frontend/src/pages/Scans/ScansView.tsx
+++ b/frontend/src/pages/Scans/ScansView.tsx
@@ -156,6 +156,7 @@ const ScansView: React.FC = () => {
     frequency: 1,
     frequencyUnit: 'minute',
     isGranular: false,
+    isUserModifiable: false,
     isSingleScan: false,
     tags: []
   });

--- a/frontend/src/types/scan.ts
+++ b/frontend/src/types/scan.ts
@@ -7,6 +7,7 @@ export interface Scan {
   frequency: number;
   lastRun: string;
   isGranular: boolean;
+  isUserModifiable: boolean;
   isSingleScan: boolean;
   organizations: [];
   tags: OrganizationTag[];


### PR DESCRIPTION
Add `isUserModifiable` option for scans. Fixes https://github.com/cisagov/crossfeed/issues/1311

Previously, all scans that were granular ("Limit enabled organizations") could be toggled on/off by organization admins directly. Now, granular scans must also have the "Allow organization admins to toggle this scan on/off" option set (which is stored as `isUserModifiable`) -- only such "user-modifiable" scans can be toggled on/off by organization admins.

![image](https://user-images.githubusercontent.com/1689183/143898351-0c57e561-e787-4281-8069-10b10ef7f64e.png)


Org admin view:

![image](https://user-images.githubusercontent.com/1689183/143898591-1fd68474-8b03-4be2-bdb2-ddd23e28d70a.png)
