### PR TITLE
Fix worker build by using new versions of packages

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine3.14
 WORKDIR /app
 COPY ./package* ./
 
-RUN npm ci
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
 
 COPY . .
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
+FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN go mod init crossfeed-worker
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
+FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
 
 WORKDIR /app
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
+FROM --platform=linux/amd64 node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN go mod init crossfeed-worker
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
+FROM --platform=linux/amd64 node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
 
 WORKDIR /app
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,4 +1,3 @@
-# Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
 FROM node:14-alpine3.14 as build
 
 WORKDIR /app
@@ -27,7 +26,6 @@ RUN go mod init crossfeed-worker
 
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
-# Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
 FROM node:14-alpine3.14
 
 WORKDIR /app

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,4 +1,5 @@
-FROM node:14-alpine3.14 as build
+# Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
+FROM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
 
 WORKDIR /app
 
@@ -26,18 +27,19 @@ RUN go mod init crossfeed-worker
 
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
-FROM node:14-alpine3.14
+# Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
+FROM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
 
 WORKDIR /app
 
-RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux-headers python3=3.9.5-r1 python3-dev py3-pip ruby=2.7.4-r0 ruby-dev zlib-dev libffi-dev libxml2-dev libxslt-dev
+RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux-headers python3=3.9.5-r2 python3-dev py3-pip ruby=2.7.5-r0 ruby-dev zlib-dev libffi-dev libxml2-dev libxslt-dev
 
 RUN npm install -g pm2@4 wait-port@0.2.9
 
-# Install intrigue ident v2.0.2. Intrigue ident supports Ruby 2.6.5, but we have 2.7.4, so we update the required Ruby version in the Gemfile so that we can run it with Ruby 2.7.4.
+# Install intrigue ident v2.0.2. Intrigue ident supports Ruby 2.6.5, but we have 2.7.5, so we update the required Ruby version in the Gemfile so that we can run it with Ruby 2.7.5.
 
 RUN gem install bundler:2.1.4
-RUN git clone https://github.com/intrigueio/intrigue-ident.git && cd intrigue-ident && git checkout e97f974417147df8fa27dcd8f73b7efbb587b942 && sed -i 's/2.6.5/2.7.4/g' Gemfile && sed -i 's/2.6.5p114/2.7.4/g' Gemfile.lock && bundle install --jobs=4
+RUN git clone https://github.com/intrigueio/intrigue-ident.git && cd intrigue-ident && git checkout e97f974417147df8fa27dcd8f73b7efbb587b942 && sed -i 's/2.6.5/2.7.5/g' Gemfile && sed -i 's/2.6.5p114/2.7.5/g' Gemfile.lock && bundle install --jobs=4
 RUN echo 'cd /app/intrigue-ident && bundle exec ruby ./util/ident.rb $@' > /usr/bin/intrigue-ident && chmod +x /usr/bin/intrigue-ident
 
 # Python dependencies

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY ./package* ./
 
-RUN npm ci
+RUN PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm ci
 
 COPY tsconfig.json ./tsconfig.json
 COPY webpack.worker.config.js ./webpack.worker.config.js

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM --platform=linux/amd64 node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
+FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN go mod init crossfeed-worker
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM --platform=linux/amd64 node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
+FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
 
 WORKDIR /app
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7 as build
+FROM node:14-alpine3.14 as build
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN go mod init crossfeed-worker
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
 # Base image is a pinned version of node:14-alpine3.14 -- see https://hub.docker.com/layers/node/library/node/14-alpine3.14/images/sha256-8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7?context=explore.
-FROM --platform=$BUILDPLATFORM node@sha256:8fd4c138ab5ea9375285354d5ff2140d275c6d47b24b0651dea6ee0733abbdf7
+FROM node:14-alpine3.14
 
 WORKDIR /app
 

--- a/backend/tools/build-worker.sh
+++ b/backend/tools/build-worker.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-DOCKER_BUILDKIT=1 docker build -t crossfeed-worker -f Dockerfile.worker .
+DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build -t crossfeed-worker -f Dockerfile.worker .

--- a/backend/tools/build-worker.sh
+++ b/backend/tools/build-worker.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build -t crossfeed-worker -f Dockerfile.worker .
+docker build -t crossfeed-worker -f Dockerfile.worker .

--- a/backend/tools/build-worker.sh
+++ b/backend/tools/build-worker.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-docker build -t crossfeed-worker -f Dockerfile.worker .
+DOCKER_BUILDKIT=1 docker build -t crossfeed-worker -f Dockerfile.worker .


### PR DESCRIPTION
Fix worker build by pinning SHA version of node:14-alpine3.14 container. Our worker build was failing because the node:14-alpine3.14 container was recently updated. This PR follows the approach in https://rockbag.medium.com/why-you-should-pin-your-docker-images-with-sha-instead-of-tags-fd132443b8a6 to pin the version of the Docker container used.

![image](https://user-images.githubusercontent.com/1689183/143900473-e8c366d3-36ab-4caf-a2b2-5b68bff74f57.png)
