### PR TITLE
Fix terraform deployment by adding proper kms permissions

### DIFF
--- a/infrastructure/kms.tf
+++ b/infrastructure/kms.tf
@@ -2,4 +2,40 @@ resource "aws_kms_key" "key" {
   description             = "KMS key"
   deletion_window_in_days = 10
   enable_key_rotation     = true
+  policy                  = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "key-default-1",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logs.${data.aws_region.current.name}.amazonaws.com"
+            },
+            "Action": [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "ArnLike": {
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+                }
+            }
+        } 
+    ]
+}
+  EOF
 }


### PR DESCRIPTION
Fix terraform deployment by adding proper kms permissions, so that the kms key can be used for CloudWatch logs.