### PR TITLE
Dynamically import dockerode to fix backend deployment errors

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Lint
         run: npm run lint
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Lint
         run: npm run lint
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2.4.0

--- a/backend/src/api/docker-events.ts
+++ b/backend/src/api/docker-events.ts
@@ -1,4 +1,3 @@
-import type Docker from 'dockerode';
 import {
   handler as updateScanTaskStatus,
   EventBridgeEvent
@@ -12,7 +11,7 @@ import {
  */
 export const listenForDockerEvents = async () => {
   const Docker = require('dockerode');
-  const docker: Docker = new Docker();
+  const docker: any = new Docker();
   const stream = await docker.getEvents();
   stream.on('data', async (chunk: any) => {
     const message = JSON.parse(Buffer.from(chunk).toString('utf-8'));

--- a/backend/src/api/docker-events.ts
+++ b/backend/src/api/docker-events.ts
@@ -1,4 +1,3 @@
-import * as Docker from 'dockerode';
 import {
   handler as updateScanTaskStatus,
   EventBridgeEvent
@@ -11,6 +10,7 @@ import {
  * This function is only used for runs during local development in order to simulate EventBridge events.
  */
 export const listenForDockerEvents = async () => {
+  const Docker = require('dockerode');
   const docker = new Docker();
   const stream = await docker.getEvents();
   stream.on('data', async (chunk: any) => {

--- a/backend/src/api/docker-events.ts
+++ b/backend/src/api/docker-events.ts
@@ -1,3 +1,4 @@
+import type Docker from 'dockerode';
 import {
   handler as updateScanTaskStatus,
   EventBridgeEvent
@@ -11,7 +12,7 @@ import {
  */
 export const listenForDockerEvents = async () => {
   const Docker = require('dockerode');
-  const docker = new Docker();
+  const docker: Docker = new Docker();
   const stream = await docker.getEvents();
   stream.on('data', async (chunk: any) => {
     const message = JSON.parse(Buffer.from(chunk).toString('utf-8'));

--- a/backend/src/tasks/ecs-client.ts
+++ b/backend/src/tasks/ecs-client.ts
@@ -1,6 +1,5 @@
 import { ECS, CloudWatchLogs } from 'aws-sdk';
 import { SCAN_SCHEMA } from '../api/scans';
-import * as Docker from 'dockerode';
 
 export interface CommandOptions {
   /** A list of organizations (id and name) that this
@@ -45,6 +44,7 @@ class ECSClient {
       isLocal ??
       (process.env.IS_OFFLINE || process.env.IS_LOCAL ? true : false);
     if (this.isLocal) {
+      const Docker = require('dockerode');
       this.docker = new Docker();
     } else {
       this.ecs = new ECS();

--- a/backend/src/tasks/ecs-client.ts
+++ b/backend/src/tasks/ecs-client.ts
@@ -1,3 +1,4 @@
+import type Docker from 'dockerode';
 import { ECS, CloudWatchLogs } from 'aws-sdk';
 import { SCAN_SCHEMA } from '../api/scans';
 

--- a/backend/src/tasks/ecs-client.ts
+++ b/backend/src/tasks/ecs-client.ts
@@ -1,4 +1,3 @@
-import type Docker from 'dockerode';
 import { ECS, CloudWatchLogs } from 'aws-sdk';
 import { SCAN_SCHEMA } from '../api/scans';
 
@@ -37,7 +36,7 @@ const toSnakeCase = (input) => input.replace(/ /g, '-');
 class ECSClient {
   ecs?: ECS;
   cloudWatchLogs?: CloudWatchLogs;
-  docker?: Docker;
+  docker?: any;
   isLocal: boolean;
 
   constructor(isLocal?: boolean) {

--- a/backend/webpack.backend.config.js
+++ b/backend/webpack.backend.config.js
@@ -23,7 +23,8 @@ module.exports = {
   },
   plugins: [
     new webpack.IgnorePlugin(/^pg-native$/),
-    new webpack.IgnorePlugin(/^canvas$/) // imported by jsdom from simple-wapplyzer, not used so we can ignore.
+    new webpack.IgnorePlugin(/^canvas$/), // imported by jsdom from simple-wapplyzer, not used so we can ignore.
+    new webpack.IgnorePlugin(/^dockerode$/) // doesn't package properly, not used in production so we can ignore.
   ],
   resolve: {
     modules: ['node_modules', 'scripts'],


### PR DESCRIPTION
Dynamically import dockerode to fix backend deployment errors.