### PR TITLE
Add domain index to service

### DIFF
--- a/backend/src/models/service.ts
+++ b/backend/src/models/service.ts
@@ -72,6 +72,7 @@ export interface Product {
 
 @Entity()
 @Index(['port', 'domain'], { unique: true })
+@Index(['domain'])
 export class Service extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;


### PR DESCRIPTION
## 🗣 Description ##

When there are many domains/services, many queries become near unusable. This seems to be due to a missing domain index on the service model, as evidenced by the following query timing:

```
 Limit  (cost=1489934.08..1489934.53 rows=15 width=45) (actual time=70529.010..70529.056 rows=15 loops=1)
   ->  Unique  (cost=1489934.08..1489940.10 rows=200 width=45) (actual time=70529.009..70529.052 rows=15 loops=1)
         ->  Sort  (cost=1489934.08..1489936.09 rows=802 width=45) (actual time=70529.008..70529.027 rows=253 loops=1)
               Sort Key: "distinctAlias".domain_name, "distinctAlias".domain_id
               Sort Method: quicksort  Memory: 298kB
               ->  Subquery Scan on "distinctAlias"  (cost=1489877.35..1489895.39 rows=802 width=45) (actual time=70526.647..70528.037 rows=2585 loops=1)
                     ->  Group  (cost=1489877.35..1489887.37 rows=802 width=2387) (actual time=70526.646..70527.775 rows=2585 loops=1)
                           Group Key: domain.id, organization.id, services.id, vulnerabilities.id
                           ->  Sort  (cost=1489877.35..1489879.35 rows=802 width=107) (actual time=70526.641..70526.796 rows=2585 loops=1)
                                 Sort Key: domain.id, services.id, vulnerabilities.id
                                 Sort Method: quicksort  Memory: 460kB
                                 ->  Hash Right Join  (cost=47274.93..1489838.66 rows=802 width=107) (actual time=7880.508..70524.417 rows=2585 loops=1)
                                       Hash Cond: (services."domainId" = domain.id)
                                       ->  Seq Scan on service services  (cost=0.00..1440721.80 rows=490380 width=32) (actual time=0.011..70451.927 rows=496068 loops=1)
                                       ->  Hash  (cost=47271.94..47271.94 rows=239 width=91) (actual time=9.893..9.896 rows=365 loops=1)
                                             Buckets: 1024  Batches: 1  Memory Usage: 46kB
                                             ->  Nested Loop  (cost=0.84..47271.94 rows=239 width=91) (actual time=0.089..9.739 rows=365 loops=1)
                                                   ->  Seq Scan on organization  (cost=0.00..2.65 rows=1 width=16) (actual time=0.016..0.021 rows=1 loops=1)
                                                         Filter: (id = 'a4ae7089-1540-4e44-af5e-8b266a0640d1'::uuid)
                                                         Rows Removed by Filter: 51
                                                   ->  Nested Loop Left Join  (cost=0.84..47266.90 rows=239 width=91) (actual time=0.071..9.650 rows=365 loops=1)
                                                         ->  Index Scan using "IDX_12375c19d3c189f4147432d209" on domain  (cost=0.42..10590.57 rows=239 width=75) (actual time=0.059..8.709 rows=122 loops=1)
                                                               Index Cond: ("organizationId" = 'a4ae7089-1540-4e44-af5e-8b266a0640d1'::uuid)
                                                         ->  Index Scan using "IDX_46829f6a4ea9ed4141dc9fc318" on vulnerability vulnerabilities  (cost=0.42..153.40 rows=6 width=32) (actual time=0.004..0.007 rows=2 loops=122)
                                                               Index Cond: ("domainId" = domain.id)
                                                               Filter: ((state)::text = 'open'::text)
 Planning Time: 0.555 ms
 Execution Time: 70529.241 ms
(28 rows)

```

Here, we see that the vast majority of time is spent on a sequential join on the services table. To fix this, we add an index on domain to the service model, which vastly improves query performance.
