### PR TITLE
Use scroll API for Elasticsearch export

### DIFF
--- a/backend/src/api/search.ts
+++ b/backend/src/api/search.ts
@@ -78,7 +78,6 @@ export const fetchAllResults = async (
     results = results.concat(
       searchResults.body.hits.hits.map((res) => res._source as Domain)
     );
-    console.log(results.length);
   }
   return results;
 };

--- a/backend/src/tasks/es-client.ts
+++ b/backend/src/tasks/es-client.ts
@@ -197,7 +197,7 @@ class ESClient {
    * @param body Elasticsearch query body.
    */
   async searchDomains(body: any, scroll?: string) {
-    let search: Search<Record<string, any>> = {
+    const search: Search<Record<string, any>> = {
       index: DOMAINS_INDEX,
       body
     };

--- a/backend/src/tasks/es-client.ts
+++ b/backend/src/tasks/es-client.ts
@@ -1,4 +1,5 @@
 import { Client } from '@elastic/elasticsearch';
+import { Search } from '@elastic/elasticsearch/api/requestParams';
 import { Domain, Webpage } from '../models';
 
 export const DOMAINS_INDEX = 'domains-5';
@@ -106,7 +107,6 @@ class ESClient {
 
   excludeFields = (domain: Domain) => {
     const copy: any = domain;
-    delete copy.ssl;
     delete copy.censysCertificatesResults;
     for (const service in copy.services) {
       delete copy.services[service].censysIpv4Results;
@@ -196,11 +196,17 @@ class ESClient {
    * Searches for domains.
    * @param body Elasticsearch query body.
    */
-  async searchDomains(body: any) {
-    return this.client.search({
+  async searchDomains(body: any, scroll?: string) {
+    let search: Search<Record<string, any>> = {
       index: DOMAINS_INDEX,
       body
-    });
+    };
+    if (scroll) search.scroll = scroll;
+    return this.client.search(search);
+  }
+
+  async scroll(scroll: string, scroll_id: string) {
+    return this.client.scroll({ scroll, scroll_id });
   }
 
   /**


### PR DESCRIPTION
## 🗣 Description ##

Crossfeed returns an error when attempting to export more than 10k entries from Elasticsearch. The error returned from Elasticsearch is `result window is too large, from + size must be less than or equal to: [10000]`. This is because Elasticsearch sets a maximum limit that can be reached to prevent overutilization of memory. From [Elastic](https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html):

> Deep Paging in Distributed Systems
> To understand why deep paging is problematic, let’s imagine that we are searching within a single index with five primary shards. When we request the first page of results (results 1 to 10), each shard produces its own top 10 results and returns them to the coordinating node, which then sorts all 50 results in order to select the overall top 10.
> 
>Now imagine that we ask for page 1,000—​results 10,001 to 10,010. Everything works in the same way except that each shard has to produce its top 10,010 results. The coordinating node then sorts through all 50,050 results and discards 50,040 of them!
>
> You can see that, in a distributed system, the cost of sorting results grows exponentially the deeper we page. There is a good reason that web search engines don’t return more than 1,000 results for any query.

Instead, Elastic recommends using the scroll API, which efficiently allows retrieving many entries. This PR implements the scroll API for the export function, allowing more than 10k results to be efficiently returned.