### PR TITLE
Fix scheduler issues

### DIFF
--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -1,6 +1,6 @@
 scheduler:
   handler: src/tasks/scheduler.handler
-  timeout: 300
+  timeout: 900
   events:
     - schedule: rate(5 minutes)
   reservedConcurrency: 1

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -175,7 +175,6 @@ class Scheduler {
       if (global) {
         // Global scans are not associated with an organization.
         if (!(await shouldRunScan({ scan }))) {
-          console.log('Skipping running scan: ', scan.name);
           continue;
         }
         await this.launchScanTask({ scan });
@@ -186,12 +185,6 @@ class Scheduler {
         const orgsToLaunch: Organization[] = [];
         for (const organization of organizations) {
           if (!(await shouldRunScan({ organization, scan }))) {
-            console.log(
-              'Skipping running scan: ',
-              scan.name,
-              ' on organization: ',
-              organization.name
-            );
             continue;
           }
           orgsToLaunch.push(organization);
@@ -202,6 +195,7 @@ class Scheduler {
           await this.launchScanTask({ organizations: orgs, scan });
         }
       }
+      console.log("Launched", this.numLaunchedTasks, "scanTasks for scan", scan.name);
       // If at least 1 new scan task was launched for this scan, update the scan
       if (this.numLaunchedTasks > prev_numLaunchedTasks) {
         scan.lastRun = new Date();

--- a/backend/src/tasks/scheduler.ts
+++ b/backend/src/tasks/scheduler.ts
@@ -195,7 +195,12 @@ class Scheduler {
           await this.launchScanTask({ organizations: orgs, scan });
         }
       }
-      console.log("Launched", this.numLaunchedTasks, "scanTasks for scan", scan.name);
+      console.log(
+        'Launched',
+        this.numLaunchedTasks,
+        'scanTasks for scan',
+        scan.name
+      );
       // If at least 1 new scan task was launched for this scan, update the scan
       if (this.numLaunchedTasks > prev_numLaunchedTasks) {
         scan.lastRun = new Date();


### PR DESCRIPTION
- Decrease logging so that scheduler has more meaningful logs
- Increase timeout so scheduler doesn't time out (this caused scans to be missed on prod)