### PR TITLE
Bump scrapy==2.6.1

### DIFF
--- a/backend/worker/requirements.txt
+++ b/backend/worker/requirements.txt
@@ -3,7 +3,6 @@ requests==2.24.0
 mitmproxy==7.0.3
 cryptography==3.3.2
 pytest==6.0.1
-# TODO: once scrapy releases version 2.6.0 with this change in it (https://github.com/scrapy/scrapy/issues/5267), switch back to using scrapy from PyPI.
-git+https://github.com/scrapy/scrapy.git@9828cb3f0bcc084c99692f19e65c2ff61a06b35a
+scrapy==2.6.1
 dnstwist==20201228
 dnspython==2.1.0


### PR DESCRIPTION
Move away from patch version in https://github.com/cisagov/crossfeed/pull/1231, as scrapy 2.6.1 has been released.