### PR TITLE
Create pesyncdb and pe.md

### DIFF
--- a/backend/src/tasks/pesyncdb.ts
+++ b/backend/src/tasks/pesyncdb.ts
@@ -1,0 +1,41 @@
+import { Handler } from 'aws-lambda';
+import { connectToDatabase } from '../models';
+
+/*
+ * Generates initial P&E database.
+ */
+
+export const handler: Handler = async (event) => {
+  const connection = await connectToDatabase();
+
+  // Create P&E database and user.
+  try {
+    await connection.query(
+      `CREATE USER ${process.env.PE_DB_USERNAME} WITH PASSWORD '${process.env.PE_DB_PASSWORD}';`
+    );
+  } catch (e) {
+    console.log(
+      "Create user failed. This usually means that the user already exists, so you're OK if that was the case. Here's the exact error:",
+      e
+    );
+  }
+  try {
+    await connection.query(
+      `GRANT ${process.env.PE_DB_USERNAME} to ${process.env.DB_USERNAME};`
+    );
+  } catch (e) {
+    console.log('Grant role failed. Error:', e);
+  }
+  try {
+    await connection.query(
+      `CREATE DATABASE ${process.env.PE_DB_NAME} owner ${process.env.PE_DB_USERNAME};`
+    );
+  } catch (e) {
+    console.log(
+      "Create database failed. This usually means that the database already exists, so you're OK if that was the case. Here's the exact error:",
+      e
+    );
+  }
+
+  console.log('Done.');
+};

--- a/docs/src/documentation-pages/dev/pe.md
+++ b/docs/src/documentation-pages/dev/pe.md
@@ -26,7 +26,7 @@ aws ssm put-parameter --name "/crossfeed/staging/PE_DATABASE_PASSWORD" --value "
 Go to the accessor instance and run:
 
 ```
-aws lambda invoke --function-name crossfeed-prod-pesyncdb --log-type Tail --region us-east-1 /dev/stderr --query 'LogResult' --output text | base64 -d
+aws lambda invoke --function-name crossfeed-staging-pesyncdb --log-type Tail --region us-east-1 /dev/stderr --query 'LogResult' --output text | base64 -d
 ```
 
 # Accessing the database

--- a/docs/src/documentation-pages/dev/pe.md
+++ b/docs/src/documentation-pages/dev/pe.md
@@ -23,7 +23,7 @@ aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_PASSWORD" --value "[ge
 
 ### Sync DB
 
-On production, go to the terraformer instance and run:
+Go to the accessor instance and run:
 
 ```
 aws lambda invoke --function-name crossfeed-prod-pesyncdb --log-type Tail --region us-east-1 /dev/stderr --query 'LogResult' --output text | base64 -d
@@ -31,7 +31,7 @@ aws lambda invoke --function-name crossfeed-prod-pesyncdb --log-type Tail --regi
 
 # Accessing the database
 
-First, retrieve the database credentials by running the following command in the terraformer instance:
+Retrieve the database credentials by running the following command in the terraformer instance:
 
 ```
 aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_NAME" --with-decryption

--- a/docs/src/documentation-pages/dev/pe.md
+++ b/docs/src/documentation-pages/dev/pe.md
@@ -1,0 +1,42 @@
+# P&E database setup instructions
+
+## Local
+
+To create the P&E database locally, first run Crossfeed with `npm start`. Then run:
+
+```
+cd backend
+npm run pesyncdb
+```
+
+## Accessor
+
+### Add credentials to SSM
+
+Before deploying. Generate a secure secret value for a database password, then run the following commands on the terraformer instance:
+
+```
+aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_NAME" --value "pe" --type "SecureString"
+aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_USER" --value "pe" --type "SecureString"
+aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_PASSWORD" --value "[generated secret password]" --type "SecureString"
+```
+
+### Sync DB
+
+On production, go to the terraformer instance and run:
+
+```
+aws lambda invoke --function-name crossfeed-prod-pesyncdb --log-type Tail --region us-east-1 /dev/stderr --query 'LogResult' --output text | base64 -d
+```
+
+# Accessing the database
+
+First, retrieve the database credentials by running the following command in the terraformer instance:
+
+```
+aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_NAME" --with-decryption
+aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_USER" --with-decryption
+aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_PASSWORD" --with-decryption
+```
+
+You can use these credentials when connecting to the database.

--- a/docs/src/documentation-pages/dev/pe.md
+++ b/docs/src/documentation-pages/dev/pe.md
@@ -16,9 +16,9 @@ npm run pesyncdb
 Before deploying. Generate a secure secret value for a database password, then run the following commands on the terraformer instance:
 
 ```
-aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_NAME" --value "pe" --type "SecureString"
-aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_USER" --value "pe" --type "SecureString"
-aws ssm put-parameter --name "/crossfeed/prod/PE_DATABASE_PASSWORD" --value "[generated secret password]" --type "SecureString"
+aws ssm put-parameter --name "/crossfeed/staging/PE_DATABASE_NAME" --value "pe" --type "SecureString"
+aws ssm put-parameter --name "/crossfeed/staging/PE_DATABASE_USER" --value "pe" --type "SecureString"
+aws ssm put-parameter --name "/crossfeed/staging/PE_DATABASE_PASSWORD" --value "[generated secret password]" --type "SecureString"
 ```
 
 ### Sync DB
@@ -34,9 +34,17 @@ aws lambda invoke --function-name crossfeed-prod-pesyncdb --log-type Tail --regi
 Retrieve the database credentials by running the following command in the terraformer instance:
 
 ```
-aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_NAME" --with-decryption
-aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_USER" --with-decryption
-aws ssm get-parameter --name "/crossfeed/prod/PE_DATABASE_PASSWORD" --with-decryption
+aws ssm get-parameter --name "/crossfeed/staging/PE_DATABASE_NAME" --with-decryption
+aws ssm get-parameter --name "/crossfeed/staging/PE_DATABASE_USER" --with-decryption
+aws ssm get-parameter --name "/crossfeed/staging/PE_DATABASE_PASSWORD" --with-decryption
 ```
 
 You can use these credentials when connecting to the database.
+
+# Populate the database with pg dump file
+
+Locate the latest postgres dump file and run:
+
+'''
+pg_restore -U pe -d pe "[path to sql dump file]"
+'''


### PR DESCRIPTION
fixes #1406

Decided not to build the database schema in pesyncdb. It will simply be a one off script to create the PE db and then we will run our pg_restore scripts in the accessor instance to populate it with our schema and data.

pe.md describes how to set up the database credentials and how to fetch them for connection.