### PR TITLE
Simplify cve open / closed vulnerability logic

### DIFF
--- a/backend/src/tasks/cve.ts
+++ b/backend/src/tasks/cve.ts
@@ -315,7 +315,7 @@ const populateVulnerabilities = async () => {
 };
 
 // Close open vulnerabilities that haven't been seen in a week.
-const closeOpenVulnerabilities = async (type: 'open' | 'closed') => {
+const closeOpenVulnerabilities = async () => {
   const oneWeekAgo = new Date(
     new Date(Date.now()).setDate(new Date(Date.now()).getDate() - 7)
   );


### PR DESCRIPTION
Simplify cve open / closed vulnerability logic. It was pretty confusing to follow the old code's logic, so hopefully this PR makes it much clearer and easier to follow.