### PR TITLE
Adjust dnstwist to run on only root domains

### DIFF
--- a/backend/src/tasks/dnstwist.ts
+++ b/backend/src/tasks/dnstwist.ts
@@ -1,14 +1,14 @@
 import { connectToDatabase, Domain, Vulnerability } from '../models';
-import getIps from './helpers/getIps';
+import getRootDomains from './helpers/getRootDomains';
 import { CommandOptions } from './ecs-client';
 import { plainToClass } from 'class-transformer';
 import saveVulnerabilitiesToDb from './helpers/saveVulnerabilitiesToDb';
 import { spawnSync } from 'child_process';
 
-async function runDNSTwist(domain: Domain) {
+async function runDNSTwist(domain: string) {
   const child = spawnSync(
     'dnstwist',
-    ['-r', '--tld', './worker/common_tlds.dict', '-f', 'json', domain.name],
+    ['-r', '--tld', './worker/common_tlds.dict', '-f', 'json', domain],
     {
       stdio: 'pipe',
       encoding: 'utf-8'
@@ -17,9 +17,9 @@ async function runDNSTwist(domain: Domain) {
   const savedOutput = child.stdout;
   const finalResults = JSON.parse(savedOutput);
   console.log(
-    `Got ${Object.keys(finalResults).length} similar domains for domain ${
-      domain.name
-    }`
+    `Got ${
+      Object.keys(finalResults).length
+    } similar domains for root domain ${domain}`
   );
   return finalResults;
 }
@@ -29,16 +29,25 @@ export const handler = async (commandOptions: CommandOptions) => {
   await connectToDatabase();
   const dateNow = new Date(Date.now());
   console.log('Running dnstwist on organization', organizationName);
-  const domainsWithIPs = await getIps(organizationId);
+  const root_domains = await getRootDomains(organizationId!);
   const vulns: Vulnerability[] = [];
-  for (const domain of domainsWithIPs) {
+  console.log(root_domains);
+  for (const root_domain of root_domains) {
     try {
-      const results = await runDNSTwist(domain);
+      const results = await runDNSTwist(root_domain);
+
+      // Fetch existing domain object
+      const domain = await Domain.findOne({
+        organization: { id: organizationId },
+        name: root_domain
+      });
+
       // Fetch existing dnstwist vulnerability
       const existingVuln = await Vulnerability.findOne({
-        domain: { id: domain.id },
+        domain: { id: domain?.id },
         source: 'dnstwist'
       });
+
       // Map date-first-observed to any domain-name that already exists
       const existingVulnsMap = {};
       if (existingVuln) {
@@ -64,7 +73,7 @@ export const handler = async (commandOptions: CommandOptions) => {
             severity: 'Low',
             needsPopulation: false,
             structuredData: { domains: results },
-            description: `Registered domains similar to ${domain.name}.`
+            description: `Registered domains similar to ${root_domain}.`
           })
         );
         await saveVulnerabilitiesToDb(vulns, false);

--- a/backend/src/tasks/test/dnstwist.test.ts
+++ b/backend/src/tasks/test/dnstwist.test.ts
@@ -172,6 +172,25 @@ describe('dnstwist', () => {
     expect(root_vuln[0].title).toEqual('DNS Twist Domains');
     expect(root_vuln[0].source).toEqual('dnstwist');
   });
+  test('root domain not in the domains table', async () => {
+    const root_domain_name = 'test-root-domain';
+    await dnstwist({
+      organizationId: organization.id,
+      organizationName: 'organizationName',
+      scanId: scan.id,
+      scanName: 'scanName',
+      scanTaskId: 'scanTaskId'
+    });
+    const root_domain = await Domain.findOne({
+      name: root_domain_name
+    });
+    const root_vuln = await Vulnerability.find({
+      domain: root_domain
+    });
+    expect(root_vuln).toHaveLength(1);
+    expect(root_vuln[0].title).toEqual('DNS Twist Domains');
+    expect(root_vuln[0].source).toEqual('dnstwist');
+  });
   test("adds new domains to existing dnstwist vulnerabilty and doesn't update the date of the existing one", async () => {
     const name = 'test-root-domain';
     const domain = await Domain.create({

--- a/backend/src/tasks/test/dnstwist.test.ts
+++ b/backend/src/tasks/test/dnstwist.test.ts
@@ -51,7 +51,7 @@ describe('dnstwist', () => {
     global.Date.now = jest.fn(() => new Date('2019-04-22T10:20:30Z').getTime());
     organization = await Organization.create({
       name: 'test-' + Math.random(),
-      rootDomains: ['test-' + Math.random()],
+      rootDomains: ['test-root-domain'],
       ipBlocks: [],
       isPassive: false
     }).save();
@@ -90,7 +90,7 @@ describe('dnstwist', () => {
   });
 
   test('creates vulnerability', async () => {
-    const name = 'test-' + Math.random();
+    const name = 'test-root-domain';
     const domain = await Domain.create({
       name,
       ip: '0.0.0.0',
@@ -139,7 +139,7 @@ describe('dnstwist', () => {
     expect(vuln[0].structuredData).toEqual(results);
   });
   test("adds new domains to existing dnstwist vulnerabilty and doesn't update the date of the existing one", async () => {
-    const name = 'test-' + Math.random();
+    const name = 'test-root-domain';
     const domain = await Domain.create({
       name,
       ip: '0.0.0.0',
@@ -202,7 +202,7 @@ describe('dnstwist', () => {
     expect(vuln[0].structuredData).toEqual(results);
   });
   test('removes dnstwist domain that no longer exists', async () => {
-    const name = 'test-' + Math.random();
+    const name = 'test-root-domain';
     const domain = await Domain.create({
       name,
       ip: '0.0.0.0',


### PR DESCRIPTION
fixes #1452

DNSTwist will now run only on root domains instead of all sub-domains. This will increase performance and ensure the database doesn't overload.