### PR TITLE
Set cookies to be "secure"

### DIFF
--- a/frontend/src/hooks/usePersistentState.ts
+++ b/frontend/src/hooks/usePersistentState.ts
@@ -20,7 +20,8 @@ export const usePersistentState = <T extends any = any>(
     localStorage.setItem(key, JSON.stringify(state));
     if (key === 'token') {
       cookies.set('crossfeed-token', state, {
-        domain: process.env.REACT_APP_COOKIE_DOMAIN
+        domain: process.env.REACT_APP_COOKIE_DOMAIN,
+        secure: true
       });
     }
   }, [state, key, cookies]);


### PR DESCRIPTION
Set cookies to be "secure" (remediates one of the WAS findings). For https://github.com/cisagov/crossfeed/issues/1462