### PR TITLE
Automatically Disable Accounts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -85,7 +85,8 @@
     "deploy-worker-staging": "./tools/deploy-worker.sh",
     "deploy-worker-prod": "./tools/deploy-worker.sh crossfeed-prod-worker",
     "syncdb": "docker-compose exec -T backend npx ts-node src/tools/run-syncdb.ts",
-    "pesyncdb": "docker-compose exec -T backend npx ts-node src/tools/run-pesyncdb.ts"
+    "pesyncdb": "docker-compose exec -T backend npx ts-node src/tools/run-pesyncdb.ts",
+    "autodisable": "docker-compose exec -T backend npx ts-node src/tools/run-autodisable.ts"
   },
   "resolutions": {
     "ansi-regex": "5.0.1"

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -163,6 +163,13 @@ export const callback = async (event, context) => {
     await user.save();
   }
 
+  if (user.disabled) {
+    return {
+      statusCode: 460,
+      body: ''
+    };
+  }
+
   user.lastLoggedIn = new Date(Date.now());
   await user.save();
 

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -165,8 +165,8 @@ export const callback = async (event, context) => {
 
   if (user.disabled) {
     return {
-      statusCode: 460,
-      body: ''
+      statusCode: 403,
+      body: 'disabled'
     };
   }
 

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -236,6 +236,7 @@ export const authorize = async (event) => {
       return parsed;
     }
     if (!user) throw Error('User does not exist');
+    if (user.disabled) throw Error('User is disabled');
     return userTokenBody(user);
   } catch (e) {
     console.error(e);

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -71,8 +71,11 @@ export const update = wrapHandler(async (event) => {
     return NotFound;
   }
   const body = await validateBody(NewUser, event.body);
-  if (!isGlobalWriteAdmin(event) && body.userType) {
-    // Non-global admins can't set userType
+  if (
+    !isGlobalWriteAdmin(event) &&
+    ('userType' in body || 'disabled' in body)
+  ) {
+    // Non-global admins can't set userType or disabled
     return Unauthorized;
   }
   const user = await User.findOne(

--- a/backend/src/api/users.ts
+++ b/backend/src/api/users.ts
@@ -88,6 +88,8 @@ export const update = wrapHandler(async (event) => {
     user.lastName = body.lastName ?? user.lastName;
     user.fullName = user.firstName + ' ' + user.lastName;
     user.userType = body.userType ?? user.userType;
+    user.disabled = body.disabled ?? user.disabled;
+
     await User.save(user);
     return {
       statusCode: 200,
@@ -115,6 +117,10 @@ class NewUser {
   @IsBoolean()
   @IsOptional()
   organizationAdmin: string;
+
+  @IsBoolean()
+  @IsOptional()
+  disabled: boolean;
 
   @IsEnum(UserType)
   @IsOptional()

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -58,6 +58,10 @@ export class User extends BaseEntity {
   @Column({ default: false })
   invitePending: boolean;
 
+  /** Whether the user's account is disabled due to inactivity */
+  @Column({ default: false })
+  disabled: boolean;
+
   /**
    * When the user accepted the terms of use,
    * if the user did so

--- a/backend/src/tasks/autoDisableAccounts.ts
+++ b/backend/src/tasks/autoDisableAccounts.ts
@@ -6,7 +6,7 @@ const INACTIVE_THRESHOLD = 60;
 
 export const handler: Handler = async (event) => {
   await connectToDatabase(true);
-  let inactiveDate = new Date();
+  const inactiveDate = new Date();
   inactiveDate.setDate(inactiveDate.getDate() - INACTIVE_THRESHOLD);
   const users = await User.find({
     lastLoggedIn: Raw((alias) => `${alias} < :date`, { date: inactiveDate })

--- a/backend/src/tasks/autoDisableAccounts.ts
+++ b/backend/src/tasks/autoDisableAccounts.ts
@@ -6,7 +6,7 @@ const INACTIVE_THRESHOLD = 60;
 
 export const handler: Handler = async (event) => {
   await connectToDatabase(true);
-  var inactiveDate = new Date();
+  let inactiveDate = new Date();
   inactiveDate.setDate(inactiveDate.getDate() - INACTIVE_THRESHOLD);
   const users = await User.find({
     lastLoggedIn: Raw((alias) => `${alias} < :date`, { date: inactiveDate })

--- a/backend/src/tasks/autoDisableAccounts.ts
+++ b/backend/src/tasks/autoDisableAccounts.ts
@@ -7,9 +7,13 @@ const INACTIVE_THRESHOLD = 60;
 export const handler: Handler = async (event) => {
   await connectToDatabase(true);
   var inactiveDate = new Date();
-  inactiveDate.setDate(inactiveDate.getDate() - INACTIVE_THRESHOLD)
+  inactiveDate.setDate(inactiveDate.getDate() - INACTIVE_THRESHOLD);
   const users = await User.find({
-    lastLoggedIn: Raw((alias) => `${alias} < :date`, { date: inactiveDate}),
+    lastLoggedIn: Raw((alias) => `${alias} < :date`, { date: inactiveDate })
   });
-  console.log(users)
+  for (let i = 0; i < users.length; i++) {
+    users[i].disabled = true;
+    await User.save(users[i]);
+  }
+  return users;
 };

--- a/backend/src/tasks/autoDisableAccounts.ts
+++ b/backend/src/tasks/autoDisableAccounts.ts
@@ -1,0 +1,15 @@
+import { Handler } from 'aws-lambda';
+import { Raw } from 'typeorm';
+import { connectToDatabase, User } from '../models';
+
+const INACTIVE_THRESHOLD = 60;
+
+export const handler: Handler = async (event) => {
+  await connectToDatabase(true);
+  var inactiveDate = new Date();
+  inactiveDate.setDate(inactiveDate.getDate() - INACTIVE_THRESHOLD)
+  const users = await User.find({
+    lastLoggedIn: Raw((alias) => `${alias} < :date`, { date: inactiveDate}),
+  });
+  console.log(users)
+};

--- a/backend/src/tasks/autoDisableAccounts.ts
+++ b/backend/src/tasks/autoDisableAccounts.ts
@@ -1,19 +1,24 @@
 import { Handler } from 'aws-lambda';
+import { DataSync } from 'aws-sdk';
 import { Raw } from 'typeorm';
+import { updateLanguageServiceSourceFile } from 'typescript';
 import { connectToDatabase, User } from '../models';
 
-const INACTIVE_THRESHOLD = 60;
+/*
+ * This handler finds all users in the database who last logged in
+ * before a set number of days, and sets those users' 'disabled'
+ * fields to true.
+ */
+
+const INACTIVE_THRESHOLD = 60; // Number of days since last log in to be considered inactive
 
 export const handler: Handler = async (event) => {
   await connectToDatabase(true);
   const inactiveDate = new Date();
   inactiveDate.setDate(inactiveDate.getDate() - INACTIVE_THRESHOLD);
-  const users = await User.find({
-    lastLoggedIn: Raw((alias) => `${alias} < :date`, { date: inactiveDate })
-  });
-  for (let i = 0; i < users.length; i++) {
-    users[i].disabled = true;
-    await User.save(users[i]);
-  }
-  return users;
+  await User.createQueryBuilder()
+    .update(User)
+    .set({ disabled: true })
+    .where('lastLoggedIn < :inactiveDate', { inactiveDate: inactiveDate })
+    .execute();
 };

--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -6,6 +6,12 @@ scheduler:
   reservedConcurrency: 1
   memorySize: 4096
 
+autoDisableAccounts:
+  handler: src/tasks/autoDisableAccounts.handler
+  timeout: 900
+  events:
+    - schedule: rate(7 days)
+
 syncdb:
   timeout: 900
   handler: src/tasks/syncdb.handler

--- a/backend/src/tools/run-autodisable.ts
+++ b/backend/src/tools/run-autodisable.ts
@@ -1,11 +1,7 @@
 import { handler as autodisable } from '../tasks/autoDisableAccounts';
 
 /**
- * Runs syncdb locally. This script is called from running "npm run syncdb".
- * Call "npm run syncdb -- -d dangerouslyforce" to force dropping and
- * recreating the SQL database.
- * Call "npm run syncdb -- -d populate" to populate the database
- * with some sample data.
+ * Runs autodisable locally. This script is called from running "npm run autodisable".
  * */
 
 process.env.DB_HOST = 'db';

--- a/backend/src/tools/run-autodisable.ts
+++ b/backend/src/tools/run-autodisable.ts
@@ -1,0 +1,15 @@
+import { handler as autodisable } from '../tasks/autoDisableAccounts';
+
+/**
+ * Runs syncdb locally. This script is called from running "npm run syncdb".
+ * Call "npm run syncdb -- -d dangerouslyforce" to force dropping and
+ * recreating the SQL database.
+ * Call "npm run syncdb -- -d populate" to populate the database
+ * with some sample data.
+ * */
+
+process.env.DB_HOST = 'db';
+process.env.DB_USERNAME = 'crossfeed';
+process.env.DB_PASSWORD = 'password';
+
+autodisable('', {} as any, () => null);

--- a/backend/test/auth.test.ts
+++ b/backend/test/auth.test.ts
@@ -151,7 +151,7 @@ describe('auth', () => {
         .send({
           token: 'TOKEN_disabledtest@crossfeed.cisa.gov'
         })
-        .expect(460);
+        .expect(403);
       expect(response.body.token).toBeFalsy();
       process.env.USE_COGNITO = '';
     });

--- a/backend/test/auth.test.ts
+++ b/backend/test/auth.test.ts
@@ -136,5 +136,24 @@ describe('auth', () => {
       );
       process.env.USE_COGNITO = '';
     });
+
+    it('verify disabled accounts cannot get tokens', async () => {
+      process.env.USE_COGNITO = '1';
+      const user = await User.create({
+        firstName: Math.random().toString(),
+        lastName: '',
+        email: 'disabledtest@crossfeed.cisa.gov',
+        dateAcceptedTerms: new Date('2020-08-03T13:58:31.715Z'),
+        disabled: true
+      }).save();
+      const response = await request(app)
+        .post('/auth/callback')
+        .send({
+          token: 'TOKEN_disabledtest@crossfeed.cisa.gov'
+        })
+        .expect(460);
+      expect(response.body.token).toBeFalsy();
+      process.env.USE_COGNITO = '';
+    });
   });
 });

--- a/backend/test/autodisable.test.ts
+++ b/backend/test/autodisable.test.ts
@@ -1,0 +1,57 @@
+import { User, connectToDatabase } from '../src/models';
+import { handler as autodisable } from '../src/tasks/autoDisableAccounts';
+
+describe('auto disable', () => {
+  beforeAll(async () => {
+    await connectToDatabase();
+  });
+  const INACTIVE_THRESHOLD = 60;
+  it(`auto disable should disable accounts that last logged in over ${INACTIVE_THRESHOLD} days ago`, async () => {
+    const days_over_thresh = [0, 1, 50, 200, 365];
+    var users: User[] = [];
+    for (let i = 0; i < days_over_thresh.length; i++) {
+      var inactiveDate = new Date();
+      inactiveDate.setDate(
+        inactiveDate.getDate() - INACTIVE_THRESHOLD - days_over_thresh[i]
+      );
+      let user = await User.create({
+        firstName: Math.random().toString(),
+        lastName: '',
+        email: Math.random() + '@crossfeed.cisa.gov',
+        dateAcceptedTerms: new Date('2020-08-03T13:58:31.715Z'),
+        lastLoggedIn: inactiveDate
+      }).save();
+      users.push(user);
+    }
+    let response = await autodisable('', {} as any, () => null);
+    for (let i = 0; i < users.length; i++) {
+      const retrievedUser = await User.findOneOrFail({
+        email: users[i].email
+      });
+      expect(retrievedUser.disabled).toEqual(true);
+    }
+  });
+  it(`auto disable should disable accounts that last logged in under ${INACTIVE_THRESHOLD} days ago`, async () => {
+    const days_back = [0, 1, 15, 30, 59];
+    var users: User[] = [];
+    for (let i = 0; i < days_back.length; i++) {
+      var inactiveDate = new Date();
+      inactiveDate.setDate(inactiveDate.getDate() - days_back[i]);
+      let user = await User.create({
+        firstName: Math.random().toString(),
+        lastName: '',
+        email: Math.random() + '@crossfeed.cisa.gov',
+        dateAcceptedTerms: new Date('2020-08-03T13:58:31.715Z'),
+        lastLoggedIn: inactiveDate
+      }).save();
+      users.push(user);
+    }
+    let response = await autodisable('', {} as any, () => null);
+    for (let i = 0; i < users.length; i++) {
+      const retrievedUser = await User.findOneOrFail({
+        email: users[i].email
+      });
+      expect(retrievedUser.disabled).toEqual(false);
+    }
+  });
+});

--- a/backend/test/autodisable.test.ts
+++ b/backend/test/autodisable.test.ts
@@ -8,13 +8,13 @@ describe('auto disable', () => {
   const INACTIVE_THRESHOLD = 60;
   it(`auto disable should disable accounts that last logged in over ${INACTIVE_THRESHOLD} days ago`, async () => {
     const days_over_thresh = [0, 1, 50, 200, 365];
-    var users: User[] = [];
+    let users: User[] = [];
     for (let i = 0; i < days_over_thresh.length; i++) {
-      var inactiveDate = new Date();
+      let inactiveDate = new Date();
       inactiveDate.setDate(
         inactiveDate.getDate() - INACTIVE_THRESHOLD - days_over_thresh[i]
       );
-      let user = await User.create({
+      const user = await User.create({
         firstName: Math.random().toString(),
         lastName: '',
         email: Math.random() + '@crossfeed.cisa.gov',
@@ -23,7 +23,7 @@ describe('auto disable', () => {
       }).save();
       users.push(user);
     }
-    let response = await autodisable('', {} as any, () => null);
+    const response = await autodisable('', {} as any, () => null);
     for (let i = 0; i < users.length; i++) {
       const retrievedUser = await User.findOneOrFail({
         email: users[i].email
@@ -33,11 +33,11 @@ describe('auto disable', () => {
   });
   it(`auto disable should disable accounts that last logged in under ${INACTIVE_THRESHOLD} days ago`, async () => {
     const days_back = [0, 1, 15, 30, 59];
-    var users: User[] = [];
+    let users: User[] = [];
     for (let i = 0; i < days_back.length; i++) {
-      var inactiveDate = new Date();
+      let inactiveDate = new Date();
       inactiveDate.setDate(inactiveDate.getDate() - days_back[i]);
-      let user = await User.create({
+      const user = await User.create({
         firstName: Math.random().toString(),
         lastName: '',
         email: Math.random() + '@crossfeed.cisa.gov',
@@ -46,7 +46,7 @@ describe('auto disable', () => {
       }).save();
       users.push(user);
     }
-    let response = await autodisable('', {} as any, () => null);
+    const response = await autodisable('', {} as any, () => null);
     for (let i = 0; i < users.length; i++) {
       const retrievedUser = await User.findOneOrFail({
         email: users[i].email

--- a/backend/test/autodisable.test.ts
+++ b/backend/test/autodisable.test.ts
@@ -31,7 +31,7 @@ describe('auto disable', () => {
       expect(retrievedUser.disabled).toEqual(true);
     }
   });
-  it(`auto disable should disable accounts that last logged in under ${INACTIVE_THRESHOLD} days ago`, async () => {
+  it(`auto disable should not disable accounts that last logged in under ${INACTIVE_THRESHOLD} days ago`, async () => {
     const days_back = [0, 1, 15, 30, 59];
     const users: User[] = [];
     for (let i = 0; i < days_back.length; i++) {

--- a/backend/test/autodisable.test.ts
+++ b/backend/test/autodisable.test.ts
@@ -8,9 +8,9 @@ describe('auto disable', () => {
   const INACTIVE_THRESHOLD = 60;
   it(`auto disable should disable accounts that last logged in over ${INACTIVE_THRESHOLD} days ago`, async () => {
     const days_over_thresh = [0, 1, 50, 200, 365];
-    let users: User[] = [];
+    const users: User[] = [];
     for (let i = 0; i < days_over_thresh.length; i++) {
-      let inactiveDate = new Date();
+      const inactiveDate = new Date();
       inactiveDate.setDate(
         inactiveDate.getDate() - INACTIVE_THRESHOLD - days_over_thresh[i]
       );
@@ -33,9 +33,9 @@ describe('auto disable', () => {
   });
   it(`auto disable should disable accounts that last logged in under ${INACTIVE_THRESHOLD} days ago`, async () => {
     const days_back = [0, 1, 15, 30, 59];
-    let users: User[] = [];
+    const users: User[] = [];
     for (let i = 0; i < days_back.length; i++) {
-      let inactiveDate = new Date();
+      const inactiveDate = new Date();
       inactiveDate.setDate(inactiveDate.getDate() - days_back[i]);
       const user = await User.create({
         firstName: Math.random().toString(),

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -683,5 +683,18 @@ describe('user', () => {
         .expect(403);
       expect(response.body).toEqual({});
     });
+    it('update by regular user should not work if changing disabled to false', async () => {
+      const response = await request(app)
+        .put(`/users/${user.id}`)
+        .set(
+          'Authorization',
+          createUserToken({
+            id: user.id
+          })
+        )
+        .send({ firstName, lastName, disabled: false })
+        .expect(403);
+      expect(response.body).toEqual({});
+    });
   });
 });

--- a/backend/test/users.test.ts
+++ b/backend/test/users.test.ts
@@ -593,6 +593,44 @@ describe('user', () => {
       expect(user.roles.length).toEqual(0);
       expect(user.userType).toEqual(UserType.GLOBAL_ADMIN);
     });
+    it('update by globalAdmin that disables user should work', async () => {
+      const response = await request(app)
+        .put(`/users/${user.id}`)
+        .set(
+          'Authorization',
+          createUserToken({
+            userType: UserType.GLOBAL_ADMIN
+          })
+        )
+        .send({ firstName, lastName, disabled: true })
+        .expect(200);
+      expect(response.body.firstName).toEqual(firstName);
+      expect(response.body.lastName).toEqual(lastName);
+      user = await User.findOne(user.id, {
+        relations: ['roles', 'roles.organization', 'roles.createdBy']
+      });
+      expect(user.roles.length).toEqual(0);
+      expect(user.disabled).toEqual(true);
+    });
+    it('update by globalAdmin that enables user should work', async () => {
+      const response = await request(app)
+        .put(`/users/${user.id}`)
+        .set(
+          'Authorization',
+          createUserToken({
+            userType: UserType.GLOBAL_ADMIN
+          })
+        )
+        .send({ firstName, lastName, disabled: false })
+        .expect(200);
+      expect(response.body.firstName).toEqual(firstName);
+      expect(response.body.lastName).toEqual(lastName);
+      user = await User.findOne(user.id, {
+        relations: ['roles', 'roles.organization', 'roles.createdBy']
+      });
+      expect(user.roles.length).toEqual(0);
+      expect(user.disabled).toEqual(false);
+    });
     it('update by globalView should not work', async () => {
       const response = await request(app)
         .put(`/users/${user.id}`)

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -81,15 +81,22 @@ export const AuthContextProvider: React.FC = ({ children }) => {
   const refreshUser = useCallback(async () => {
     if (!token && process.env.REACT_APP_USE_COGNITO) {
       const session = await Auth.currentSession();
-      const { token } = await apiPost<{ token: string; user: User }>(
-        '/auth/callback',
-        {
-          body: {
-            token: session.getIdToken().getJwtToken()
+      try {
+        const { token } = await apiPost<{ token: string; user: User }>(
+          '/auth/callback',
+          {
+            body: {
+              token: session.getIdToken().getJwtToken()
+            }
           }
+        );
+        setToken(token);
+      } catch (error) {
+        const e = error.toString();
+        if (e.slice(-3, e.length) === '460') {
+          alert('Account disabled. Contact global admin for assistance.');
         }
-      );
-      setToken(token);
+      }
     }
   }, [apiPost, setToken, token]);
 

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -91,9 +91,8 @@ export const AuthContextProvider: React.FC = ({ children }) => {
           }
         );
         setToken(token);
-      } catch (error) {
-        const e = error.toString();
-        if (e.slice(-3, e.length) === '460') {
+      } catch (e) {
+        if (e.response.data === 'disabled') {
           alert('Account disabled. Contact global admin for assistance.');
         }
       }

--- a/frontend/src/pages/Organization/Organization.tsx
+++ b/frontend/src/pages/Organization/Organization.tsx
@@ -116,6 +116,14 @@ export const Organization: React.FC = () => {
       disableFilters: true
     },
     {
+      Header: 'Status',
+      accessor: ({ user }) => (user.disabled ? 'Disabled' : 'Enabled'),
+      width: 150,
+      minWidth: 150,
+      id: 'disabled',
+      disableFilters: true
+    },
+    {
       Header: () => {
         return (
           <div style={{ justifyContent: 'flex-center' }}>

--- a/frontend/src/pages/Users/Users.tsx
+++ b/frontend/src/pages/Users/Users.tsx
@@ -185,12 +185,6 @@ export const Users: React.FC = () => {
       });
       setUsers(users.filter((user) => user.id !== row.id).concat(user));
     } catch (e) {
-      setErrors({
-        global:
-          e.status === 422
-            ? 'Unable to update disabled status for user'
-            : e.message ?? e.toString()
-      });
       console.log(e);
     }
   };

--- a/frontend/src/test-utils/user.ts
+++ b/frontend/src/test-utils/user.ts
@@ -4,6 +4,7 @@ export const testUser: AuthUser = {
   id: 'd7d6e913-0370-4f43-aebc-6bd727adc70e',
   createdAt: '2020-08-23T03:36:57.231Z',
   updatedAt: '2020-08-23T03:36:57.231Z',
+  disabled: false,
   lastLoggedIn: new Date().toISOString(),
   firstName: 'John',
   lastName: 'Smith',

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -9,6 +9,7 @@ export interface User {
   lastName: string;
   fullName: string;
   invitePending: boolean;
+  disabled: boolean;
   userType: 'standard' | 'globalView' | 'globalAdmin';
   email: string;
   roles: Role[];


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Adds the ability to disable/re-enable user accounts for global admins, and a lambda function that automatically disables accounts that have been inactive for over 60 days. Disabled accounts are able to initially authenticate via Login.gov, but will not receive an authorization token from the callback endpoint.

## 💭 Motivation and context ##

See issue #958 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
