### PR TITLE
Remove "Scans" page from org view

### DIFF
--- a/frontend/src/pages/Organization/Organization.tsx
+++ b/frontend/src/pages/Organization/Organization.tsx
@@ -747,7 +747,7 @@ export const Organization: React.FC = () => {
   if (!organization.parent) {
     navItems = navItems.concat([
       // { title: 'Teams', path: `/organizations/${organizationId}/teams` },
-      { title: 'Scans', path: `/organizations/${organizationId}/scans` }
+      // { title: 'Scans', path: `/organizations/${organizationId}/scans` }
     ]);
   }
 


### PR DESCRIPTION
Remove "Scans" page for now, because issues https://github.com/cisagov/crossfeed/issues/1380 and https://github.com/cisagov/crossfeed/issues/902 make it not actually show useful information anymore. We should fix both issues before re-adding this page.

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/1689183/194346431-b8ed5a11-d901-41de-a6ed-7bff4817734a.png">
