### PR TITLE
add missing default values for worker

### DIFF
--- a/infrastructure/vars.tf
+++ b/infrastructure/vars.tf
@@ -89,17 +89,17 @@ variable "ssm_lambda_subnet" {
 
 variable "ssm_worker_sg" {
   type    = string
-  default = ""
+  default = "/crossfeed/staging/WORKER_SG_ID"
 }
 
 variable "ssm_worker_subnet" {
   type    = string
-  default = ""
+  default = "/crossfeed/staging/WORKER_SUBNET_ID"
 }
 
 variable "ssm_worker_arn" {
   type    = string
-  default = ""
+  default = "/crossfeed/staging/WORKER_CLUSTER_ARN"
 }
 
 variable "db_table_name" {


### PR DESCRIPTION
fixes #1533

## 🗣 Description ##

Fix bug in terraform that is removing policies in prod (AmazonSSMManagedInstanceCore, AmazonEC2RoleforSSM)

## 💭 Motivation and context ##

Cannot connect to the accessor without these policies.

