### PR TITLE
Upgrade worker deps

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -77,10 +77,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: 3.9
+          python-version: 3.10
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,10 +77,10 @@ jobs:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: 3.9
+          python-version: 3.10
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -35,9 +35,9 @@ RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux
 
 RUN npm install -g pm2@4 wait-port@0.2.9
 
-# Install intrigue ident v2.0.2. Intrigue ident supports Ruby 2.6.5, but we have $RUBY_VERSION, so we update the required Ruby version in the Gemfile so that we can run it with Ruby $RUBY_VERSION.
+# Install intrigue ident v2.0.2. Intrigue ident supports Ruby 2.7.2, but we have $RUBY_VERSION, so we update the required Ruby version in the Gemfile so that we can run it with Ruby $RUBY_VERSION.
 
-RUN gem install bundler:2.1.4
+RUN gem install bundler:2.3.21
 RUN export RUBY_VERSION=$(ruby -e "print RUBY_VERSION") && git clone https://github.com/intrigueio/intrigue-ident.git && cd intrigue-ident && git checkout ee119abeac20564e728a92ab786400126e7a97f0 && sed -i "s/2.7.2/$RUBY_VERSION/g" Gemfile && sed -i "s/2.7.2p114/$RUBY_VERSION/g" Gemfile.lock && bundle install --jobs=4
 RUN echo 'cd /app/intrigue-ident && bundle exec ruby ./util/ident.rb $@' > /usr/bin/intrigue-ident && chmod +x /usr/bin/intrigue-ident
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -31,7 +31,7 @@ FROM node:14-alpine3.14
 
 WORKDIR /app
 
-RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux-headers python3=3.9.15-r0 python3-dev py3-pip ruby ruby-dev zlib-dev libffi-dev libxml2-dev libxslt-dev postgresql-dev gcc musl-dev py3-pandas py3-scikit-learn cargo
+RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux-headers python3=3.9.16-r0 python3-dev py3-pip ruby ruby-dev zlib-dev libffi-dev libxml2-dev libxslt-dev postgresql-dev gcc musl-dev py3-pandas py3-scikit-learn cargo
 
 RUN npm install -g pm2@4 wait-port@0.2.9
 
@@ -45,7 +45,8 @@ RUN echo 'cd /app/intrigue-ident && bundle exec ruby ./util/ident.rb $@' > /usr/
 
 COPY worker/requirements.txt worker/requirements.txt
 
-RUN pip install --no-cache-dir -r worker/requirements.txt
+# mitmproxy-wireguard is not supported on Alpine and is not needed for mitmproxy's functionality, so we skip it.
+RUN pip install --no-cache-dir -r worker/requirements.txt --no-deps mitmproxy_wireguard
 
 COPY worker worker
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.14 as build
+FROM node:14-alpine3.17 as build
 USER root
 
 WORKDIR /app
@@ -31,7 +31,7 @@ FROM node:14-alpine3.14
 
 WORKDIR /app
 
-RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux-headers python3=3.9.16-r0 python3-dev py3-pip ruby ruby-dev zlib-dev libffi-dev libxml2-dev libxslt-dev postgresql-dev gcc musl-dev py3-pandas py3-scikit-learn cargo
+RUN apk add --update --no-cache wget build-base curl git unzip openssl-dev linux-headers python3=3.10.9-r1 python3-dev py3-pip ruby ruby-dev zlib-dev libffi-dev libxml2-dev libxslt-dev postgresql-dev gcc musl-dev py3-pandas py3-scikit-learn cargo
 
 RUN npm install -g pm2@4 wait-port@0.2.9
 
@@ -45,8 +45,7 @@ RUN echo 'cd /app/intrigue-ident && bundle exec ruby ./util/ident.rb $@' > /usr/
 
 COPY worker/requirements.txt worker/requirements.txt
 
-# mitmproxy-wireguard is not supported on Alpine and is not needed for mitmproxy's functionality, so we skip it.
-RUN pip install --no-cache-dir -r worker/requirements.txt --no-deps mitmproxy_wireguard
+RUN pip install --no-cache-dir -r worker/requirements.txt
 
 COPY worker worker
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -27,7 +27,7 @@ RUN go mod init crossfeed-worker
 
 RUN go get github.com/facebookincubator/nvdtools/...@v0.1.4
 
-FROM node:14-alpine3.14
+FROM node:14-alpine3.17
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN npm install -g pm2@4 wait-port@0.2.9
 # Install intrigue ident v2.0.2. Intrigue ident supports Ruby 2.6.5, but we have $RUBY_VERSION, so we update the required Ruby version in the Gemfile so that we can run it with Ruby $RUBY_VERSION.
 
 RUN gem install bundler:2.1.4
-RUN export RUBY_VERSION=$(ruby -e "print RUBY_VERSION") && git clone https://github.com/intrigueio/intrigue-ident.git && cd intrigue-ident && git checkout e97f974417147df8fa27dcd8f73b7efbb587b942 && sed -i "s/2.6.5/$RUBY_VERSION/g" Gemfile && sed -i "s/2.6.5p114/$RUBY_VERSION/g" Gemfile.lock && bundle install --jobs=4
+RUN export RUBY_VERSION=$(ruby -e "print RUBY_VERSION") && git clone https://github.com/intrigueio/intrigue-ident.git && cd intrigue-ident && git checkout ee119abeac20564e728a92ab786400126e7a97f0 && sed -i "s/2.7.2/$RUBY_VERSION/g" Gemfile && sed -i "s/2.7.2p114/$RUBY_VERSION/g" Gemfile.lock && bundle install --jobs=4
 RUN echo 'cd /app/intrigue-ident && bundle exec ruby ./util/ident.rb $@' > /usr/bin/intrigue-ident && chmod +x /usr/bin/intrigue-ident
 
 # Python dependencies

--- a/backend/worker/requirements.txt
+++ b/backend/worker/requirements.txt
@@ -1,7 +1,7 @@
 requests-http-signature==0.2.0
 requests==2.28.1
-mitmproxy==8.1.1
-cryptography==37.0.4
+mitmproxy==9.0.1
+cryptography==38.0.4
 pytest==7.1.2
 scrapy==2.6.2
 dnstwist==20220815


### PR DESCRIPTION
Upgrade worker dependencies:
- upgrade python because 3.9.15-r0 is no longer available on the alpine image
- upgrade mitmproxy to 9
- upgrade cryptography to 38