### PR TITLE
Disable IAM authentication for matomo db

### DIFF
--- a/infrastructure/matomo.tf
+++ b/infrastructure/matomo.tf
@@ -195,7 +195,7 @@ resource "aws_db_instance" "matomo_db" {
   multi_az                            = false
   backup_retention_period             = 35
   storage_encrypted                   = true
-  iam_database_authentication_enabled = true
+  iam_database_authentication_enabled = false
 
   // database information
   db_name  = "matomo"


### PR DESCRIPTION
Because it's not supported

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/1689183/218363334-75c668c6-d815-40e8-89f0-02a67822b9b3.png">
