### PR TITLE
Fix amass install by updating the link

### DIFF
--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -21,7 +21,7 @@ RUN apk add --no-cache wget unzip
 
 RUN wget --quiet https://github.com/Edu4rdSHL/findomain/releases/download/5.1.1/findomain-linux -O /usr/bin/findomain && chmod +x /usr/bin/findomain
 
-RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp amass-3.7.3 /usr/bin/amass && chmod +x /usr/bin/amass
+RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp -r amass-3.7.3 /usr/bin/amass && chmod +x /usr/bin/amass
 
 RUN go mod init crossfeed-worker
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -21,7 +21,7 @@ RUN apk add --no-cache wget unzip
 
 RUN wget --quiet https://github.com/Edu4rdSHL/findomain/releases/download/5.1.1/findomain-linux -O /usr/bin/findomain && chmod +x /usr/bin/findomain
 
-RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp amass_linux_i386/amass /usr/bin && chmod +x /usr/bin/amass
+RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp amass-3.7.3 /usr/bin/amass && chmod +x /usr/bin/amass
 
 RUN go mod init crossfeed-worker
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -21,7 +21,7 @@ RUN apk add --no-cache wget unzip
 
 RUN wget --quiet https://github.com/Edu4rdSHL/findomain/releases/download/5.1.1/findomain-linux -O /usr/bin/findomain && chmod +x /usr/bin/findomain
 
-RUN wget --quiet https://github.com/OWASP/Amass/releases/download/v3.7.3/amass_linux_i386.zip -O amass.zip && unzip -q amass.zip && cp amass_linux_i386/amass /usr/bin && chmod +x /usr/bin/amass
+RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp amass_linux_i386/amass /usr/bin && chmod +x /usr/bin/amass
 
 RUN go mod init crossfeed-worker
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -21,7 +21,7 @@ RUN apk add --no-cache wget unzip
 
 RUN wget --quiet https://github.com/Edu4rdSHL/findomain/releases/download/5.1.1/findomain-linux -O /usr/bin/findomain && chmod +x /usr/bin/findomain
 
-RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp amass-3.7.3 /usr/bin && mv /usr/bin/amass-3.7.3 /usr/bin/amass && chmod +x /usr/bin/amass
+RUN wget --quiet https://github.com/OWASP/Amass/releases/download/v3.22.2/amass_linux_i386.zip -O amass.zip && unzip -q amass.zip && cp amass_linux_i386/amass /usr/bin && chmod +x /usr/bin/amass
 
 RUN go mod init crossfeed-worker
 

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -21,7 +21,7 @@ RUN apk add --no-cache wget unzip
 
 RUN wget --quiet https://github.com/Edu4rdSHL/findomain/releases/download/5.1.1/findomain-linux -O /usr/bin/findomain && chmod +x /usr/bin/findomain
 
-RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp -r amass-3.7.3 /usr/bin/amass && chmod +x /usr/bin/amass
+RUN wget --quiet https://github.com/owasp-amass/amass/archive/refs/tags/v3.7.3.zip -O amass.zip && unzip -q amass.zip && cp amass-3.7.3 /usr/bin && mv /usr/bin/amass-3.7.3 /usr/bin/amass && chmod +x /usr/bin/amass
 
 RUN go mod init crossfeed-worker
 


### PR DESCRIPTION
## 🗣 Description ##

![Screen Shot 2023-03-29 at 10 03 49 AM](https://user-images.githubusercontent.com/79927030/228563535-2703eae5-103b-452e-a5a5-c5d16b306525.png)

Amass is failing in the Dockerfile.worker. I think the old install link has been deprecated in [releases](https://github.com/owasp-amass/amass/releases) .

Upgraded to the latest version. Link below describes the differences.

https://github.com/owasp-amass/amass/compare/v3.7.3...v3.22.2

