### PR TITLE
Fix proxy to P&E API

### DIFF
--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -163,7 +163,6 @@ const matomoProxy = createProxyMiddleware({
  */
 const peProxy = createProxyMiddleware({
   target: process.env.PE_API_URL,
-  changeOrigin: true,
   pathRewrite: function (path, req) {
     return path.replace(/^\/pe/, '');
   }

--- a/backend/src/api/app.ts
+++ b/backend/src/api/app.ts
@@ -163,7 +163,10 @@ const matomoProxy = createProxyMiddleware({
  */
 const peProxy = createProxyMiddleware({
   target: process.env.PE_API_URL,
-  changeOrigin: true
+  changeOrigin: true,
+  pathRewrite: function (path, req) {
+    return path.replace(/^\/pe/, '');
+  }
 });
 
 app.use(


### PR DESCRIPTION

## 🗣 Description ##

Added pathRewrite to the P&E proxy because the Crossfeed endpoint, /pe, doesn't exist in the P&E app.

## 🧪 Testing ##

Was able to set up both apps locally and get successful results performing this request:

```
url = "http://localhost:3000/pe/apiv1/cidrs"
headers = {
    "Authorization": <crossfeed-api-key>,
    "Content-Type": "application/orjson",
    "access_token": <pe-api-key>,
}
response = requests.post(url, headers=headers)
print(response.text)
```
*localhost:3000 is the REACT_APP_API_URL