### PR TITLE
Remove extraneous "jwt must be provided" log

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -114,7 +114,6 @@ export const callback = async (event, context) => {
       userInfo = (await callback_(JSON.parse(event.body))) as UserInfo;
     }
   } catch (e) {
-    console.error(e);
     return {
       statusCode: 500,
       body: ''


### PR DESCRIPTION
This isn't really an error because sometimes we call the API anonymously. Removing this log as it clutters the logs

```
backend_1   | JsonWebTokenError: jwt must be provided
backend_1   |     at Object.module.exports [as verify] (/app/node_modules/jsonwebtoken/verify.js:53:17)
backend_1   |     at /app/src/api/auth.ts:211:20
backend_1   |     at step (/app/src/api/auth.ts:33:23)
backend_1   |     at Object.next (/app/src/api/auth.ts:14:53)
backend_1   |     at fulfilled (/app/src/api/auth.ts:5:58)
backend_1   |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
```