### PR TITLE
Fix docs architecture diagram

### DIFF
--- a/docs/src/templates/documentation-page.js
+++ b/docs/src/templates/documentation-page.js
@@ -43,7 +43,7 @@ const DocumentationPage = ({ data, location }) => {
               {fields.slug === '/dev/architecture/' && (
                 <div style={{ marginTop: 20 }}>
                   <iframe
-                    srcDoc={diagramHTML}
+                    srcDoc={diagramHTML.default}
                     style={{ width: '100%', minHeight: 800, border: 0 }}
                   ></iframe>
                 </div>


### PR DESCRIPTION
Fixes https://github.com/cisagov/crossfeed/issues/1822. I think it broke with the latest upgrade to gatsby. I used the approach in https://stackoverflow.com/questions/59070216/webpack-file-loader-outputs-object-module to fix it.