### PR TITLE
Replacing pandas version

### DIFF
--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -46,7 +46,7 @@ RUN export LD_LIBRARY_PATH=/opt/OpenBLAS/lib:$LD_LIBRARY_PATH
 
 # Install pe-source module
 # Sync the latest from cf-staging branch
-RUN git clone -b cf-source-staging https://github.com/cisagov/pe-reports.git && cd pe-reports && git checkout c9cbbd73b22ef38cabe1da6ba50aeb2dc0be4f99 && pip install .
+RUN git clone -b cf-source-staging https://github.com/cisagov/pe-reports.git && cd pe-reports && git checkout c9cbbd73b22ef38cabe1da6ba50aeb2dc0be4f99 && sed -i 's/pandas == 1.1.5/pandas == 1.5.1/g' setup.py && pip install .
 
 
 # Python dependencies


### PR DESCRIPTION
Replacing inline the pandas version to skip building the wheel and use the one from base image.

## 🗣 Description ##
We use sed to replace the current version with one that has a prebuilt wheel in alpine base image. This reduces the build time significantly.

## 🧪 Testing ##
Building the backend.

## ✅ Pre-approval checklist ##
- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

