### PR TITLE
Fix reports API documentation

### DIFF
--- a/backend/src/api/reports.ts
+++ b/backend/src/api/reports.ts
@@ -6,7 +6,7 @@ import { getOrgMemberships } from './auth';
  * @swagger
  *
  * /reports/export:
- *  get:
+ *  post:
  *    description: Export CyHy report by specifying the S3 key returned in /reports/list and the organization id. User must be a member of the organization.
  *    tags:
  *    - Reports
@@ -39,7 +39,7 @@ export const export_report = wrapHandler(async (event) => {
  * @swagger
  *
  * /reports/list:
- *  get:
+ *  post:
  *    description: Get a list of available P&E reports by specifying organization id. User must be a member of the organization.
  *    tags:
  *    - Reports


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Change the Swagger documentation for the two reports API endpoints from `get` to `post` to correctly reflect how they are implemented.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
