### PR TITLE
ljf - Prevent navigation if the a tag is selected in the header dropdown when on an organization page Fixes 1872 

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -58,6 +58,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
   const [organizations, setOrganizations] = useState<
     (Organization | OrganizationTag)[]
   >([]);
+  const [tags, setTags] = useState<OrganizationTag[]>([]);
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -76,6 +77,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       let tags: (OrganizationTag | Organization)[] = [];
       if (userLevel === GLOBAL_ADMIN) {
         tags = await apiGet<OrganizationTag[]>('/organizations/tags');
+        setTags(tags as OrganizationTag[]);
       }
       setOrganizations(tags.concat(rows));
     } catch (e) {
@@ -300,7 +302,9 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
 
                           // Check if we're on an organization page and, if so, update it to the new organization
                           if (orgPageMatch !== null) {
-                            history.push(`/organizations/${value.id}`);
+                            if (!tags.find((e) => e.id === value.id)) {
+                              history.push(`/organizations/${value.id}`);
+                            }
                           }
                         } else {
                           setShowAllOrganizations(true);


### PR DESCRIPTION
## 🗣 Description ##

This update will prevent the user from navigating to a page that doesn't exist on the server. 
If the user is on an an individual organization page selecting one of the organizations in the header dropdown box should navigate the user to the selected organizations individual organization page. 

The issue occurs when a user selects a tag from the list instead of another organization. Crossfeed then routes the user to the /organizations/{id} route that replaces the id with the tag id, but that page doesn't have anything on it yet.  We want to limit the users to only be able to select the organizations from the dropdown. They can still see the tags listed, but if they select it, it will stay on the current organization, but update the context accordingly. So if they go back to the homepage, everything would be filtered by the selected tag.  

The organization selection should remain the same after these changes are put in.

## 💭 Motivation and context ##

A user can select a tag on an individual organization page, but it will only update if and only if they select a different organization, not a tag. 

This will Fix 1872 

## 🧪 Testing ##

Manual testing: 
- Navigate to an organizations individual page as a global admin and select a tag from the dropdown.  It should change the selection on the header field only and not naviage to the /organizations/{id} for the tag chose.
- Then choose a different organization and ensure that it follows the route to the new organization and shows information about the current chosen organization.


## 📷 Screenshots (if appropriate) ##

<img width="1419" alt="Screenshot 2023-05-10 at 11 28 35 AM" src="https://github.com/cisagov/crossfeed/assets/125403621/fec23822-c7b2-4db2-80b3-d55bf68e0dff">

This shows that the individual organization page is loaded, but a different tag is selected. 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##


- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
