### PR TITLE
LJF - Fix 1836 Swagger codegen on docker start.

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -17,9 +17,8 @@ RUN npm i --legacy-peer-deps
 # Generate swagger definitions
 COPY ./backend ../backend
 COPY ./docs .
-RUN npm run codegen
 
 # Configure port used by Gatsby
 ENV INTERNAL_STATUS_PORT=44475
 
-CMD [ "npm", "run", "develop", "--", "-H", "0.0.0.0", "--port", "4000"]
+CMD npm run codegen; npm run develop -- -H 0.0.0.0 --port 4000


### PR DESCRIPTION
## 🗣 Description ##

The timing of the codegen is done can affect the ability for swagger to start. There is an issue for some computers where if we create the swagger.json that allows the swagger process to start and inject it into the image, the process will load an either partially corrupted swagger.json or not upload one at all. 

The container has all the required tools to create the codegen when the docker container starts, so it will be fresh every time and not rely on a bad codegen.


## 💭 Motivation and context ##

Closes 1836. This issue was fixed for in a previous PR, but the behavior has returned even after the update. 

## 🧪 Testing ##

Manual testing, Make sure that the docs container starts and continues to run. It will give output to navigate to localhost:4000 and once everything is up and running, look in that location to see that it is working.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
