### PR TITLE
Turn on Cloudwatch logging for Postgres

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -23,6 +23,7 @@ resource "aws_db_instance" "db" {
   backup_retention_period             = 35
   storage_encrypted                   = true
   iam_database_authentication_enabled = true
+  enabled_cloudwatch_logs_exports     = ["postgresql","upgrade"]
 
   // database information
   db_name  = var.db_table_name

--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -23,7 +23,7 @@ resource "aws_db_instance" "db" {
   backup_retention_period             = 35
   storage_encrypted                   = true
   iam_database_authentication_enabled = true
-  enabled_cloudwatch_logs_exports     = ["postgresql","upgrade"]
+  enabled_cloudwatch_logs_exports     = ["postgresql", "upgrade"]
 
   // database information
   db_name  = var.db_table_name


### PR DESCRIPTION
## 🗣 Description ##

Turn on Cloudwatch logging for the PostgreSQL database on AWS via Terraform.

Based on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#enabled_cloudwatch_logs_exports

## 💭 Motivation and context ##

Provide logs