### PR TITLE
Hiding the error overlay frame in dev mode.

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -23,6 +23,10 @@ body {
   background-color: color('base-lightest');
 }
 
+body>iframe {
+  display: none;
+}
+
 .cisa-crossfeed-loading {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
Hiding the error overlay frame in dev mode.

## 🗣 Description ##
Using css to remove the error overlay in dev mode. The error overlay window/frame was introduced in react-scripts v5 (as a result of upgrade due to vulnerabilities). 
While using react-script there is no way to override the behavior. 
There are some methods to avoid this but they are more involved. (see https://marmelab.com/blog/2021/07/22/cra-webpack-no-eject.html)
The solution implemented is described here:
https://stackoverflow.com/questions/46589819/disable-error-overlay-in-development-mode

## 💭 Motivation and context ##
The change is required to avoid unnecessary clicks during development work.

## 🧪 Testing ##
A standard user was created and used to log-in. Observe: the overlay error doesn't happen anymore.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

