### PR TITLE
Allow Major Version Update of Postgres in Terraform

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -18,6 +18,7 @@ resource "aws_db_instance" "db" {
   storage_type                        = "gp2"
   engine                              = "postgres"
   engine_version                      = "14.4"
+  allow_major_version_upgrade         = true
   skip_final_snapshot                 = true
   availability_zone                   = data.aws_availability_zones.available.names[0]
   multi_az                            = false


### PR DESCRIPTION
To allow for major_version change in Postgres the statement `allow_major_version_upgrade = true` was added.

This is based on the Terraform documentation at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance .

## 🗣 Description ##

Allows for the automated database upgrade of Postgres to 14.4.  The Terraform was previously missing the major_upgrade line.

## 💭 Motivation and context ##

Terraform will not allow for the jump from 11 to 14 without this line.

## 🧪 Testing ##

Tested locally.  Previously upgraded Postgres in the docker-compose file to jump from 11 to 14 and there was no negative effect.


## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
