### PR TITLE
Added timeout for containers / End after 1 day (24 hours)

### DIFF
--- a/backend/worker/worker-entry.sh
+++ b/backend/worker/worker-entry.sh
@@ -22,7 +22,7 @@ export AWS_CA_BUNDLE=/usr/local/share/ca-certificates/mitmproxy-ca-cert.crt
 # Main code
 echo "Running main code..."
 
-timeout -k 1d 1d node --unhandled-rejections=strict worker.bundle.js
+timeout 1d node --unhandled-rejections=strict worker.bundle.js
 
 pm2 stop all | grep "^\[PM2\]"
 

--- a/backend/worker/worker-entry.sh
+++ b/backend/worker/worker-entry.sh
@@ -22,7 +22,7 @@ export AWS_CA_BUNDLE=/usr/local/share/ca-certificates/mitmproxy-ca-cert.crt
 # Main code
 echo "Running main code..."
 
-node --unhandled-rejections=strict worker.bundle.js
+timeout -k 1d 1d node --unhandled-rejections=strict worker.bundle.js
 
 pm2 stop all | grep "^\[PM2\]"
 


### PR DESCRIPTION
## 🗣 Description ##

Added a timeout of 1 day to the containers.  Will limit local Docker scans and AWS Fargate containers to 1 day of running before killing.

## 💭 Motivation and context ##

Fargate containers are currently running for lengthy periods of time with no graceful (or ungraceful) way to end.  The timeout will now close them after 24 hours.

## 🧪 Testing ##

Tested locally with a variety of times.
1s or 1 second
30s or 30 seconds
10m or 10 minutes

Those with short times on the timeout exit before completing.  Those with a longer period complete as expected.  

![image](https://github.com/cisagov/crossfeed/assets/126006749/e3142a99-8ca5-4858-931d-81a7d3b71833)

![image](https://github.com/cisagov/crossfeed/assets/126006749/86d27b29-77ef-4595-942f-0b1e06456f53)


## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
