### PR TITLE
Issue 1850 Concept. Add dialog to Organization Upload page to show outcome. 

### DIFF
--- a/frontend/src/pages/Organizations/Organizations.tsx
+++ b/frontend/src/pages/Organizations/Organizations.tsx
@@ -3,13 +3,33 @@ import React, { useCallback, useState } from 'react';
 import { ImportExport } from 'components';
 import { Organization } from 'types';
 import { useAuthContext } from 'context';
-import { makeStyles } from '@material-ui/core';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  makeStyles
+} from '@material-ui/core';
 import { OrganizationList } from 'components/OrganizationList';
 
 export const Organizations: React.FC = () => {
   const { user, apiGet, apiPost } = useAuthContext();
   const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogText, setDialogText] = useState('');
+  const [successCount, setSuccessCount] = useState(0);
+  const [failureCount, setFailureCount] = useState(0);
   const classes = useStyles();
+
+  const handleClose = () => {
+    window.location.reload();
+    setDialogOpen(false);
+  };
+
+  const setWarningMessage = () => {
+    setDialogText('There was an error');
+  };
 
   const fetchOrganizations = useCallback(async () => {
     try {
@@ -67,12 +87,18 @@ export const Organizations: React.FC = () => {
                         }
                       })
                     );
+                    setSuccessCount((e) => (e = e + 1));
                   } catch (e: any) {
                     console.error('Error uploading Entry: ' + e);
+                    setFailureCount((e) => (e = e + 1));
+                    setWarningMessage();
                   }
                 }
+                if (!dialogText.includes('error')) {
+                  setDialogText('All Organizations Successfully Entered');
+                }
+                setDialogOpen(true);
                 setOrganizations(organizations.concat(...createdOrganizations));
-                window.location.reload();
               }}
               getDataToExport={() =>
                 organizations.map(
@@ -87,6 +113,21 @@ export const Organizations: React.FC = () => {
           </>
         )}
       </div>
+      <Dialog open={dialogOpen} onClose={handleClose}>
+        <DialogTitle id="alert-dialog-title">
+          {'Organization Upload Feedback:'}
+        </DialogTitle>
+        <DialogContent>
+          <div> Successful uploads: {successCount}</div>
+          <div> Failed uploads: {failureCount}</div>
+          <div> {dialogText} </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} autoFocus>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## 🗣 Description ##

Added a dialog that opens once the import function is done that will show the number of successful and failed uploads.

We can add to this, but this could be considered the MVP for now and we can add this type of feedback to more types of functionality.
## 💭 Motivation and context ##

The user needs more info about things they are doing. The Organization Import function should have some feedback to the user. If we want to add a notification panel, that might be a good start. We could read off every error into the notification panel and extend it more and more.  Just an idea.

## 🧪 Testing ##

Manual testing. Try uploading some organizations and it should pop up with how many failed and succeeded.

## 📷 Screenshots (if appropriate) ##
<img width="395" alt="Screenshot 2023-06-02 at 11 55 03 AM" src="https://github.com/cisagov/crossfeed/assets/125403621/19619ad3-8a9c-451e-9d58-e8d70f261adf">

## ✅ Pre-approval checklist ##


- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
