### PR TITLE
Fix frontend deploy by updating runner for gha

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm run test
   deploy_staging:
     needs: [lint, test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: staging
     concurrency: 1
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -92,7 +92,7 @@ jobs:
 
   deploy_prod:
     needs: [lint, test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: production
     concurrency: 1
     if: github.event_name == 'push' && github.ref == 'refs/heads/production'


### PR DESCRIPTION
The reason why the frontend deploys weren't working is because `ubuntu-18.04` is no longer supported by GHA as of April 1, 2023, so we need to change it to `ubuntu-latest` -- see https://stackoverflow.com/questions/70959954/error-waiting-for-a-runner-to-pick-up-this-job-using-github-actions.