### PR TITLE
Fix syncdb by locking elasticsearch to 7.10.x

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@elastic/elasticsearch": "^7.9.1",
+        "@elastic/elasticsearch": "~7.10.0",
         "@thefaultvault/tfv-cpe-parser": "^1.3.0",
         "@types/node-fetch": "^2.6.4",
         "@types/papaparse": "^5.3.0",
@@ -2504,17 +2504,18 @@
       }
     },
     "node_modules/@elastic/elasticsearch": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.17.0.tgz",
-      "integrity": "sha512-5QLPCjd0uLmLj1lSuKSThjNpq39f6NmlTy9ROLFwG5gjyTgpwSqufDeYG/Fm43Xs05uF7WcscoO7eguI3HuuYA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.10.0.tgz",
+      "integrity": "sha512-vXtMAQf5/DwqeryQgRriMtnFppJNLc/R7/R0D8E+wG5/kGM5i7mg+Hi7TM4NZEuXgtzZ2a/Nf7aR0vLyrxOK/w==",
       "dependencies": {
-        "debug": "^4.3.1",
+        "debug": "^4.1.1",
         "hpagent": "^0.1.1",
-        "ms": "^2.1.3",
-        "secure-json-parse": "^2.4.0"
+        "ms": "^2.1.1",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^2.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "~7.10.0",
     "@thefaultvault/tfv-cpe-parser": "^1.3.0",
     "@types/node-fetch": "^2.6.4",
     "@types/papaparse": "^5.3.0",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Lock elasticsearch version to 7.10.x to fix compatibilty error in syncdb: 

https://github.com/cisagov/crossfeed/actions/runs/5424040124/jobs/9863058526


## 💭 Motivation and context ##
AWS will not support elasticsearch > 7.10. 

https://aws.amazon.com/what-is/opensearch/#seo-faq-pairs#will-amazon-opensearch-service-support-new-elasticsearch-versions-beyond-7-10

