### PR TITLE
Updated header (Nav Bar) for hiding reports page

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -249,7 +249,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
     { title: 'Feeds', path: '/feeds', users: ALL_USERS, exact: false },
 
     /* 
-    hiding reprts page until finished 
+    Hiding Reports page until finished 
     {
       title: 'Reports',
       path: '/reports',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -247,12 +247,12 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       exact: false
     },
     { title: 'Feeds', path: '/feeds', users: ALL_USERS, exact: false },
-    {
+   /* {
       title: 'Reports',
       path: '/reports',
       users: ALL_USERS,
       exact: true
-    },
+    },*/
     {
       title: 'Scans',
       path: '/scans',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -247,17 +247,16 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       exact: false
     },
     { title: 'Feeds', path: '/feeds', users: ALL_USERS, exact: false },
-<<<<<<< Updated upstream
-   /* {
-=======
-
+   
+    /* 
+    hiding reprts page until finished 
     {
->>>>>>> Stashed changes
       title: 'Reports',
       path: '/reports',
       users: ALL_USERS,
       exact: true
     },*/
+    
     {
       title: 'Scans',
       path: '/scans',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -423,11 +423,10 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
                         ) {
                           return options;
                         }
-                        return options.filter(
-                          (option) =>
-                            option?.name
-                              .toLowerCase()
-                              .includes(state.inputValue.toLowerCase())
+                        return options.filter((option) =>
+                          option?.name
+                            .toLowerCase()
+                            .includes(state.inputValue.toLowerCase())
                         );
                       }}
                       disableClearable

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -247,7 +247,12 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       exact: false
     },
     { title: 'Feeds', path: '/feeds', users: ALL_USERS, exact: false },
+<<<<<<< Updated upstream
    /* {
+=======
+
+    {
+>>>>>>> Stashed changes
       title: 'Reports',
       path: '/reports',
       users: ALL_USERS,

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -247,7 +247,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       exact: false
     },
     { title: 'Feeds', path: '/feeds', users: ALL_USERS, exact: false },
-   
+
     /* 
     hiding reprts page until finished 
     {
@@ -256,7 +256,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       users: ALL_USERS,
       exact: true
     },*/
-    
+
     {
       title: 'Scans',
       path: '/scans',
@@ -423,10 +423,11 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
                         ) {
                           return options;
                         }
-                        return options.filter((option) =>
-                          option?.name
-                            .toLowerCase()
-                            .includes(state.inputValue.toLowerCase())
+                        return options.filter(
+                          (option) =>
+                            option?.name
+                              .toLowerCase()
+                              .includes(state.inputValue.toLowerCase())
                         );
                       }}
                       disableClearable

--- a/frontend/src/components/__tests__/__snapshots__/header.spec.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/header.spec.tsx.snap
@@ -60,17 +60,6 @@ exports[`Header component matches snapshot 1`] = `
                 Feeds
               </a>
             </div>
-            <div
-              class="css-g2ra7n"
-            >
-              <a
-                class="NavItem-link"
-                href="/reports"
-                style="outline: none;"
-              >
-                Reports
-              </a>
-            </div>
           </div>
           <div
             class="Header-spacing"

--- a/frontend/src/test-utils/organization.ts
+++ b/frontend/src/test-utils/organization.ts
@@ -9,5 +9,6 @@ export const testOrganization = {
   granularScans: [],
   tags: [],
   parent: null,
-  children: []
+  children: [],
+  pendingDomains: []
 };

--- a/frontend/src/types/organization.ts
+++ b/frontend/src/types/organization.ts
@@ -14,7 +14,7 @@ export interface Organization {
   tags: OrganizationTag[];
   parent: Organization | null;
   children: Organization[];
-  pendingDomains: PendingDomain[];
+  pendingDomains?: PendingDomain[];
 }
 
 export interface PendingDomain {

--- a/frontend/src/types/organization.ts
+++ b/frontend/src/types/organization.ts
@@ -14,7 +14,7 @@ export interface Organization {
   tags: OrganizationTag[];
   parent: Organization | null;
   children: Organization[];
-  pendingDomains?: PendingDomain[];
+  pendingDomains: PendingDomain[];
 }
 
 export interface PendingDomain {


### PR DESCRIPTION
Hiding Reports page 
due to no current data being presented needed to hide this page until it gets updated. 
frontend/src/components/Header.tsx
commented out line 250-255 to hide page.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

frontend/src/components/Header.tsx
comment out line 250-255 to hide the page.

Will need to uncomment when reports page is finished.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Clients get confused on reports page when nothing is presented currently. 
<!-- What problem does this change solve? How did you solve it? -->
gives dev team a chance to update the reports page

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
used local crossed to verify changes 

![Screenshot 2023-09-13 at 9 03 35 AM](https://github.com/cisagov/crossfeed/assets/126171978/5e9068bc-faa2-4e09-8a36-02c7a93d1fb0)

before when reports page was present to

![Screenshot 2023-09-13 at 9 35 24 AM](https://github.com/cisagov/crossfeed/assets/126171978/5e0ae848-9bab-4d72-beb9-74b6619409b0)


reports page hide on the nav bar.

