### PR TITLE
updating the nav bar to hide feeds page until finished

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -246,7 +246,14 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       users: ALL_USERS,
       exact: false
     },
-    { title: 'Feeds', path: '/feeds', users: ALL_USERS, exact: false },
+
+    /* 
+    Hiding Feeds page until finished 
+    { title: 'Feeds', 
+      path: '/feeds', 
+      users: ALL_USERS, 
+      exact: false 
+    },*/
 
     /* 
     Hiding Reports page until finished 
@@ -423,10 +430,11 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
                         ) {
                           return options;
                         }
-                        return options.filter((option) =>
-                          option?.name
-                            .toLowerCase()
-                            .includes(state.inputValue.toLowerCase())
+                        return options.filter(
+                          (option) =>
+                            option?.name
+                              .toLowerCase()
+                              .includes(state.inputValue.toLowerCase())
                         );
                       }}
                       disableClearable

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -431,9 +431,9 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
                           return options;
                         }
                         return options.filter((option) =>
-                            option?.name
-                              .toLowerCase()
-                              .includes(state.inputValue.toLowerCase())
+                          option?.name
+                            .toLowerCase()
+                            .includes(state.inputValue.toLowerCase())
                         );
                       }}
                       disableClearable

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -247,13 +247,13 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       exact: false
     },
 
-     
+    /* 
     Hiding Feeds page until finished. 
     { title: 'Feeds', 
       path: '/feeds', 
       users: ALL_USERS, 
       exact: false 
-    },
+    },*/
 
     /* 
     Hiding Reports page until finished. 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -248,7 +248,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
     },
 
     /* 
-    Hiding Feeds page until finished 
+    Hiding Feeds page until finished. 
     { title: 'Feeds', 
       path: '/feeds', 
       users: ALL_USERS, 
@@ -256,7 +256,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
     },*/
 
     /* 
-    Hiding Reports page until finished 
+    Hiding Reports page until finished. 
     {
       title: 'Reports',
       path: '/reports',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -247,13 +247,13 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
       exact: false
     },
 
-    /* 
+     
     Hiding Feeds page until finished. 
     { title: 'Feeds', 
       path: '/feeds', 
       users: ALL_USERS, 
       exact: false 
-    },*/
+    },
 
     /* 
     Hiding Reports page until finished. 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -248,7 +248,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
     },
 
     /* 
-    Hiding Feeds page until finished. 
+    Hiding Feeds page until finished
     { title: 'Feeds', 
       path: '/feeds', 
       users: ALL_USERS, 
@@ -256,7 +256,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
     },*/
 
     /* 
-    Hiding Reports page until finished. 
+    Hiding Reports page until finished 
     {
       title: 'Reports',
       path: '/reports',

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -430,8 +430,7 @@ const HeaderNoCtx: React.FC<ContextType> = (props) => {
                         ) {
                           return options;
                         }
-                        return options.filter(
-                          (option) =>
+                        return options.filter((option) =>
                             option?.name
                               .toLowerCase()
                               .includes(state.inputValue.toLowerCase())

--- a/frontend/src/components/__tests__/__snapshots__/header.spec.tsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/header.spec.tsx.snap
@@ -49,17 +49,6 @@ exports[`Header component matches snapshot 1`] = `
                 Inventory
               </a>
             </div>
-            <div
-              class="css-g2ra7n"
-            >
-              <a
-                class="NavItem-link"
-                href="/feeds"
-                style="outline: none;"
-              >
-                Feeds
-              </a>
-            </div>
           </div>
           <div
             class="Header-spacing"


### PR DESCRIPTION
## 🗣 Description ##

Hiding Feeds page
due to no current data being presented needed to hide this page until it gets updated.
frontend/src/components/Header.tsx
commented out line 251-256 to hide page.


## 💭 Motivation and context ##

<!-- Why is this change required? -->
Clients get confused on feeds page when nothing is presented currently. 
<!-- What problem does this change solve? How did you solve it? -->
gives dev team a chance to update the feeds page

## 🧪 Testing ##

used local crossed to verify changes

before feeds page changes were made:
![Screenshot 2023-09-25 at 4 28 42 PM](https://github.com/cisagov/crossfeed/assets/126171978/bf3f4b77-8117-4110-b44d-126aeae264a2)

after feeds page became hidden from nav bar:
![Screenshot 2023-09-25 at 4 27 35 PM](https://github.com/cisagov/crossfeed/assets/126171978/7e670ff6-2974-4e47-a9e8-fd3128221538)





