### PR TITLE
Footer cutting off bottom of all pages

### DIFF
--- a/frontend/src/components/Footer/styleFooter.ts
+++ b/frontend/src/components/Footer/styleFooter.ts
@@ -11,7 +11,7 @@ export const footerClasses = {
 };
 export const FooterRoot = styled('div')(({ theme }) => ({
   [`& .${footerClasses.footerBox}`]: {
-    position: 'absolute',
+    position: 'fix',
     bottom: 0,
     width: '100%',
     backgroundColor: theme.palette.primary.main

--- a/frontend/src/components/Footer/styleFooter.ts
+++ b/frontend/src/components/Footer/styleFooter.ts
@@ -11,7 +11,8 @@ export const footerClasses = {
 };
 export const FooterRoot = styled('div')(({ theme }) => ({
   [`& .${footerClasses.footerBox}`]: {
-    position: 'fix',
+    position: 'relative',
+    top: '20px',
     bottom: 0,
     width: '100%',
     backgroundColor: theme.palette.primary.main


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Page footer currently cuts off "Export Users" section of "Users" page, to include cutting off other pages within crossfeed. User is unable to scroll past footer or page in order to reach export section or cuts off information on other pages.

go to frontend/src/components/footer/styleFooter.ts


## 🧪 Testing ##

Will be using local crossfeed to make and update changes.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->