### PR TITLE
Add network_configuration to aws_ecs_service (pe-worker-shodan)

### DIFF
--- a/backend/src/tasks/functions.yml
+++ b/backend/src/tasks/functions.yml
@@ -33,7 +33,7 @@ scanExecution:
   handler: src/tasks/scanExecution.handler
   timeout: 300 # 5 minutes
   environment:
-    SQS_QUEUE_NAME: ${self:provider.stage}-worker-queue
+    SQS_QUEUE_NAME: ${self:provider.stage}-worker-control-queue
   events:
     - sqs:
         arn:

--- a/infrastructure/pe_worker.tf
+++ b/infrastructure/pe_worker.tf
@@ -177,7 +177,7 @@ resource "aws_ecs_service" "shodan_service" {
   launch_type     = "FARGATE"
   desired_count   = 0 # Initially set to 0, plan to start it dynamically
   network_configuration {
-    subnets         = aws_subnet.worker.id
+    subnets         = aws_subnet.worker.*.id
     security_groups = [aws_security_group.worker.id]
   }
 }

--- a/infrastructure/pe_worker.tf
+++ b/infrastructure/pe_worker.tf
@@ -176,4 +176,8 @@ resource "aws_ecs_service" "shodan_service" {
   task_definition = aws_ecs_task_definition.pe_worker.arn
   launch_type     = "FARGATE"
   desired_count   = 0 # Initially set to 0, plan to start it dynamically
+  network_configuration {
+    subnets         = aws_subnet.worker.id
+    security_groups = [aws_security_group.worker.id]
+  }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Creating a new ECS service failed because we didn't set the network configuration. This is required if the task_definition network mode is set to awsvpc.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#network_configuration