### PR TITLE
Add PE worker log group and make sure desired count gets set back to 0

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -43,6 +43,9 @@ provider:
           Action:
             - ecs:RunTask
             - ecs:ListTasks
+            - ecs:DescribeTasks
+            - ecs:DescribeServices
+            - ecs:UpdateService
             - iam:PassRole
           Resource: '*'
         - Effect: Allow
@@ -65,7 +68,9 @@ provider:
         - Effect: Allow
           Action:
             - sqs:ReceiveMessage
+            - sqs:DeleteMessage
             - sqs:SendMessage
+            - sqs:GetQueueAttributes
           Resource: '*'
         - Effect: Allow
           Action:
@@ -107,7 +112,6 @@ resources:
         VisibilityTimeout: 300
         MaximumMessageSize: 262144 # 256 KB
         MessageRetentionPeriod: 604800 # 7 days
-
 
 functions:
   - ${file(./src/tasks/functions.yml)}

--- a/infrastructure/pe_worker.tf
+++ b/infrastructure/pe_worker.tf
@@ -185,7 +185,7 @@ resource "aws_ecs_service" "shodan_service" {
 
 # Create the  log group
 resource "aws_cloudwatch_log_group" "pe_worker" {
-  name              = var.pe_worker_ecs_log_group_name # should match awslogs-group in service.json
+  name              = var.pe_worker_ecs_log_group_name
   retention_in_days = 3653
   kms_key_id        = aws_kms_key.key.arn
   tags = {

--- a/infrastructure/pe_worker.tf
+++ b/infrastructure/pe_worker.tf
@@ -184,7 +184,7 @@ resource "aws_ecs_service" "shodan_service" {
 }
 
 # Create the  log group
-resource "aws_cloudwatch_log_group" "worker" {
+resource "aws_cloudwatch_log_group" "pe_worker" {
   name              = var.pe_worker_ecs_log_group_name # should match awslogs-group in service.json
   retention_in_days = 3653
   kms_key_id        = aws_kms_key.key.arn

--- a/infrastructure/pe_worker.tf
+++ b/infrastructure/pe_worker.tf
@@ -177,7 +177,20 @@ resource "aws_ecs_service" "shodan_service" {
   launch_type     = "FARGATE"
   desired_count   = 0 # Initially set to 0, plan to start it dynamically
   network_configuration {
-    subnets         = aws_subnet.worker.*.id
-    security_groups = [aws_security_group.worker.id]
+    subnets          = aws_subnet.worker.id
+    security_groups  = [aws_security_group.worker.id]
+    assign_public_ip = true
+  }
+}
+
+# Create the  log group
+resource "aws_cloudwatch_log_group" "worker" {
+  name              = var.pe_worker_ecs_log_group_name # should match awslogs-group in service.json
+  retention_in_days = 3653
+  kms_key_id        = aws_kms_key.key.arn
+  tags = {
+    Project = var.project
+    Stage   = var.stage
+    Owner   = "Crossfeed managed resource"
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

The pe-staging-worker log group isn't created automatically so need to add this to the terraform.

Another oversight is when the desired count is set to 5, we need to make sure that when all the messages have gone through, we reset the desired count to 0 so that no more fargate tasks run.

