### PR TITLE
Make pe-worker-entry.sh executable

### DIFF
--- a/backend/Dockerfile.pe
+++ b/backend/Dockerfile.pe
@@ -9,6 +9,8 @@ COPY src ./src
 
 RUN apt update && apt install git zlib1g-dev
 
+RUN apt-get update && apt-get install -y jq
+
 RUN wget -c https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tar.xz && tar -Jxvf Python-3.10.11.tar.xz
 RUN cd Python-3.10.11 && ./configure && make -j4 && make altinstall
 RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python3.10 1

--- a/backend/worker/pe-worker-entry.sh
+++ b/backend/worker/pe-worker-entry.sh
@@ -1,6 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+
+echo "Starting pe-worker-entry.sh script"
 
 # Check if the SHODAN_QUEUE_URL environment variable is set
 if [ -z "$SHODAN_QUEUE_URL" ]; then


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

In order to run pe-worker-entry.sh from the Dockerfile.pe, it has to be an executable bash file. So this PR,

1. Makes pe-worker-entry.sh executable
2. Refines the shebang
3. Adds another comment at the start
4. Makes sure the jq command is installed
