### PR TITLE
Remove VPC Endpoints from Serverless Frontend

### DIFF
--- a/frontend/env.yml
+++ b/frontend/env.yml
@@ -3,11 +3,9 @@ dev:
 
 staging:
   DOMAIN: 'staging-cd.crossfeed.cyber.dhs.gov'
-  VPC_ENDPOINT: ${ssm:/crossfeed/staging/BACKEND_VPC_ENDPOINT}
 
 prod:
   DOMAIN: 'crossfeed.cyber.dhs.gov'
-  VPC_ENDPOINT: ${ssm:/crossfeed/prod/BACKEND_VPC_ENDPOINT}
 
 dev-vpc:
   securityGroupIds:

--- a/frontend/serverless.yml
+++ b/frontend/serverless.yml
@@ -23,24 +23,10 @@ provider:
   stage: ${opt:stage, 'dev'}
   environment: ${file(env.yml):${self:provider.stage}, ''}
   vpc: ${file(env.yml):${self:provider.stage}-vpc, ''}
-  vpcEndpointIds:
-    - vpce-0f012d56c2afb9c1d
   apiGateway:
     binaryMediaTypes:
       - 'image/*'
       - 'font/*'
-    resourcePolicy: 
-      - Effect: Deny
-        Principal: "*"
-        Action: "execute-api:Invoke"
-        Resource: "execute-api:/${self:provider.stage}/*/*"
-        Condition:
-          StringNotEquals:
-            "aws:sourceVpce": "vpce-0f012d56c2afb9c1d"
-      - Effect: Allow
-        Principal: "*"
-        Action: "execute-api:Invoke"
-        Resource: "execute-api:/${self:provider.stage}/*/*"
   logs:
     restApi: true
   deploymentBucket:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Remove VPC Endpoints from Serverless Frontend (Not needed with NAT gateway)

Frontend deployent was failing because SSM couldn't find the BACKEND_VPC_ENDPOINT
