### PR TITLE
Fix Frontend Pipeline: Add resource policy to API Gateway

### DIFF
--- a/frontend/serverless.yml
+++ b/frontend/serverless.yml
@@ -27,6 +27,11 @@ provider:
     binaryMediaTypes:
       - 'image/*'
       - 'font/*'
+    resourcePolicy:
+      - Effect: Allow
+        Principal: '*'
+        Action: 'execute-api:Invoke'
+        Resource: 'execute-api:/${self:provider.stage}/*/*'
   logs:
     restApi: true
   deploymentBucket:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Fix this error:
https://github.com/cisagov/crossfeed/actions/runs/7477853608/job/20351662987


Private Rest API's require a resource policy, so add what is being used in the gov cloud (minus the vpc endpoint restriction)