### PR TITLE
Add namespace to aws_cloudwatch_metric_alarm

### DIFF
--- a/infrastructure/api_gateway_alarms.tf
+++ b/infrastructure/api_gateway_alarms.tf
@@ -10,6 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "api_error_rate" {
   statistic           = "Average"
   unit                = "Count"
   treat_missing_data  = "notBreaching"
+  namespace           = var.log_metric_namespace
 
   tags = {
     Project  = var.project


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Bug that is causing the infrastructure pipeline to fail. See here:
https://github.com/cisagov/crossfeed/actions/runs/7506627532/job/20438453930

Added namespace to failing resource.

