### PR TITLE
Add SQS permissions to Fargate task role

### DIFF
--- a/infrastructure/worker.tf
+++ b/infrastructure/worker.tf
@@ -150,6 +150,16 @@ resource "aws_iam_role_policy" "worker_task_role_policy" {
       "Resource": [
         "${aws_s3_bucket.export_bucket.arn}"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "sqs:ListQueues",
+        "sqs:GetQueueAttributes"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The Fargate containers need permission to read/write to the SQS queues. 

The right permissions were added to the execution role but also need to be in the task role. 