### PR TITLE
Convert backend API to private

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -12,7 +12,7 @@ custom:
     basePath: ''
     certificateName: ${file(env.yml):${self:provider.stage}.DOMAIN, ''}
     stage: ${self:provider.stage}
-    createRoute53Record: true
+    createRoute53Record: false
 
 provider:
   name: aws
@@ -132,4 +132,5 @@ functions:
 
 plugins:
   - serverless-domain-manager
+  - serverless-better-credentials
   - serverless-webpack

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -132,5 +132,4 @@ functions:
 
 plugins:
   - serverless-domain-manager
-  - serverless-better-credentials
   - serverless-webpack

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -17,6 +17,7 @@ custom:
 provider:
   name: aws
   region: us-east-1
+  endpointType: PRIVATE
   runtime: nodejs16.x
   timeout: 30
   stage: ${opt:stage, 'dev'}
@@ -26,6 +27,11 @@ provider:
     binaryMediaTypes:
       - 'image/*'
       - 'font/*'
+    resourcePolicy:
+      - Effect: Allow
+        Principal: '*'
+        Action: 'execute-api:Invoke'
+        Resource: 'execute-api:/${self:provider.stage}/*/*'
   logs:
     restApi: true
   deploymentBucket:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -16,8 +16,7 @@ custom:
 
 provider:
   name: aws
-  region: us-gov-east-1
-  endpointType: PRIVATE
+  region: us-east-1
   runtime: nodejs16.x
   timeout: 30
   stage: ${opt:stage, 'dev'}
@@ -27,11 +26,6 @@ provider:
     binaryMediaTypes:
       - 'image/*'
       - 'font/*'
-    resourcePolicy:
-      - Effect: Allow
-        Principal: '*'
-        Action: 'execute-api:Invoke'
-        Resource: 'execute-api:/${self:provider.stage}/*/*'
   logs:
     restApi: true
   deploymentBucket:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -16,7 +16,8 @@ custom:
 
 provider:
   name: aws
-  region: us-east-1
+  region: us-gov-east-1
+  endpointType: PRIVATE
   runtime: nodejs16.x
   timeout: 30
   stage: ${opt:stage, 'dev'}
@@ -26,6 +27,11 @@ provider:
     binaryMediaTypes:
       - 'image/*'
       - 'font/*'
+    resourcePolicy:
+      - Effect: Allow
+        Principal: '*'
+        Action: 'execute-api:Invoke'
+        Resource: 'execute-api:/${self:provider.stage}/*/*'
   logs:
     restApi: true
   deploymentBucket:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Convert the backend API to regional private. This is how we have it configured in the govcloud, so it is best to keep it consistent. Also, it was an edge-optimized API gateway which requires the use of cloudfront (we no longer want to use).