### PR TITLE
Change API Gateways to Regional

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -17,7 +17,7 @@ custom:
 provider:
   name: aws
   region: us-east-1
-  endpointType: PRIVATE
+  endpointType: REGIONAL
   runtime: nodejs16.x
   timeout: 30
   stage: ${opt:stage, 'dev'}

--- a/frontend/serverless.yml
+++ b/frontend/serverless.yml
@@ -17,7 +17,7 @@ custom:
 provider:
   name: aws
   region: us-east-1
-  endpointType: PRIVATE
+  endpointType: REGIONAL
   runtime: nodejs16.x
   timeout: 30
   stage: ${opt:stage, 'dev'}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

API Gateways need to be Regional instead of PRIVATE in order for it to be reachable. This is just for the staging-cd environment, not the Gov Cloud accounts.
